### PR TITLE
Migrating away from EncryptedSharedPreferences

### DIFF
--- a/app/src/main/java/app/passwordstore/Application.kt
+++ b/app/src/main/java/app/passwordstore/Application.kt
@@ -59,7 +59,8 @@ class Application : android.app.Application(), SharedPreferences.OnSharedPrefere
     prefs.registerOnSharedPreferenceChangeListener(this)
     setNightMode()
     setUpBouncyCastleForSshj()
-    runMigrations(filesDirPath, prefs, gitSettings)
+    val context: Context = getApplicationContext()
+    runMigrations(filesDirPath, prefs, gitSettings, context)
     proxyUtils.setDefaultProxy()
     DynamicColors.applyToActivitiesIfAvailable(this)
     Sentry.configureScope { scope ->

--- a/app/src/main/java/app/passwordstore/injection/prefs/GitPreferences.kt
+++ b/app/src/main/java/app/passwordstore/injection/prefs/GitPreferences.kt
@@ -6,9 +6,9 @@
 package app.passwordstore.injection.prefs
 
 import android.content.SharedPreferences
-import javax.inject.Qualifier
+
 
 /**
  * Qualifies a [SharedPreferences] instance specifically used for encrypted Git-related settings.
  */
-@Qualifier @Retention(AnnotationRetention.RUNTIME) annotation class GitPreferences
+// @Qualifier @Retention(AnnotationRetention.RUNTIME) annotation class GitPreferences

--- a/app/src/main/java/app/passwordstore/injection/prefs/PreferenceModule.kt
+++ b/app/src/main/java/app/passwordstore/injection/prefs/PreferenceModule.kt
@@ -8,8 +8,6 @@ package app.passwordstore.injection.prefs
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
 import android.content.SharedPreferences
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
 import app.passwordstore.BuildConfig
 import dagger.Module
 import dagger.Provides
@@ -22,7 +20,7 @@ import dagger.hilt.components.SingletonComponent
 @InstallIn(SingletonComponent::class)
 class PreferenceModule {
 
-  private fun createEncryptedPreferences(context: Context, fileName: String): SharedPreferences {
+  /* private fun createEncryptedPreferences(context: Context, fileName: String): SharedPreferences {
     val masterKeyAlias =
       MasterKey.Builder(context).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build()
     return EncryptedSharedPreferences.create(
@@ -32,25 +30,25 @@ class PreferenceModule {
       EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
       EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
     )
-  }
+  } */
 
-  @[Provides PasswordGeneratorPreferences Reusable]
+  /* @[Provides PasswordGeneratorPreferences Reusable]
   fun providePwgenPreferences(@ApplicationContext context: Context): SharedPreferences {
     return createEncryptedPreferences(context, "pwgen_preferences")
-  }
+  } */
 
   @[Provides SettingsPreferences Reusable]
   fun provideSettingsPreferences(@ApplicationContext context: Context): SharedPreferences {
     return context.getSharedPreferences("${BuildConfig.APPLICATION_ID}_preferences", MODE_PRIVATE)
   }
 
-  @[Provides GitPreferences Reusable]
+  /*  @[Provides GitPreferences Reusable]
   fun provideGitPreferences(@ApplicationContext context: Context): SharedPreferences {
     return createEncryptedPreferences(context, "git_operation")
-  }
+  } */
 
-  @[Provides ProxyPreferences Reusable]
+  /* @[Provides ProxyPreferences Reusable]
   fun provideProxyPreferences(@ApplicationContext context: Context): SharedPreferences {
     return createEncryptedPreferences(context, "http_proxy")
-  }
+  } */
 }

--- a/app/src/main/java/app/passwordstore/injection/prefs/ProxyPreferences.kt
+++ b/app/src/main/java/app/passwordstore/injection/prefs/ProxyPreferences.kt
@@ -6,9 +6,9 @@
 package app.passwordstore.injection.prefs
 
 import android.content.SharedPreferences
-import javax.inject.Qualifier
+
 
 /**
  * Qualifies a [SharedPreferences] instance specifically used for encrypted proxy-related settings.
  */
-@Qualifier @Retention(AnnotationRetention.RUNTIME) annotation class ProxyPreferences
+// @Qualifier @Retention(AnnotationRetention.RUNTIME) annotation class ProxyPreferences

--- a/app/src/main/java/app/passwordstore/ui/dialogs/DicewarePasswordGeneratorDialogFragment.kt
+++ b/app/src/main/java/app/passwordstore/ui/dialogs/DicewarePasswordGeneratorDialogFragment.kt
@@ -17,7 +17,7 @@ import androidx.fragment.app.setFragmentResult
 import androidx.lifecycle.lifecycleScope
 import app.passwordstore.R
 import app.passwordstore.databinding.FragmentPwgenDicewareBinding
-import app.passwordstore.injection.prefs.PasswordGeneratorPreferences
+import app.passwordstore.injection.prefs.SettingsPreferences
 import app.passwordstore.passgen.diceware.DicewarePassphraseGenerator
 import app.passwordstore.ui.crypto.PasswordCreationActivity
 import app.passwordstore.util.extensions.getString
@@ -34,7 +34,7 @@ import reactivecircus.flowbinding.android.widget.afterTextChanges
 class DicewarePasswordGeneratorDialogFragment : DialogFragment() {
 
   @Inject lateinit var dicewareGenerator: DicewarePassphraseGenerator
-  @Inject @PasswordGeneratorPreferences lateinit var prefs: SharedPreferences
+  @Inject @SettingsPreferences lateinit var prefs: SharedPreferences
 
   override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
     val builder = MaterialAlertDialogBuilder(requireContext())

--- a/app/src/main/java/app/passwordstore/ui/git/base/BaseGitActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/git/base/BaseGitActivity.kt
@@ -4,11 +4,9 @@
  */
 package app.passwordstore.ui.git.base
 
-import android.content.SharedPreferences
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.edit
 import app.passwordstore.R
-import app.passwordstore.injection.prefs.GitPreferences
 import app.passwordstore.util.coroutines.DispatcherProvider
 import app.passwordstore.util.extensions.sharedPrefs
 import app.passwordstore.util.git.ErrorMessages
@@ -56,7 +54,6 @@ abstract class BaseGitActivity : AppCompatActivity() {
 
   @Inject lateinit var gitSettings: GitSettings
   @Inject lateinit var dispatcherProvider: DispatcherProvider
-  @GitPreferences @Inject lateinit var gitPrefs: SharedPreferences
 
   /**
    * Poor workaround to pass in a specified remote branch for [ResetToRemoteOperation]. Callers of
@@ -103,7 +100,6 @@ abstract class BaseGitActivity : AppCompatActivity() {
   suspend fun promptOnErrorHandler(err: Throwable, onPromptDone: () -> Unit = {}) {
     val error = rootCauseException(err)
     if (!isExplicitlyUserInitiatedError(error)) {
-      gitPrefs.edit { remove(PreferenceKeys.HTTPS_PASSWORD) }
       sharedPrefs.edit { remove(PreferenceKeys.SSH_OPENKEYSTORE_KEYID) }
       logcat { error.asLog() }
       withContext(dispatcherProvider.main()) {

--- a/app/src/main/java/app/passwordstore/ui/proxy/ProxySelectorActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/proxy/ProxySelectorActivity.kt
@@ -19,7 +19,7 @@ import androidx.core.os.postDelayed
 import androidx.core.widget.doOnTextChanged
 import app.passwordstore.R
 import app.passwordstore.databinding.ActivityProxySelectorBinding
-import app.passwordstore.injection.prefs.ProxyPreferences
+import app.passwordstore.injection.prefs.SettingsPreferences
 import app.passwordstore.util.extensions.getString
 import app.passwordstore.util.extensions.viewBinding
 import app.passwordstore.util.proxy.ProxyUtils
@@ -32,7 +32,7 @@ import javax.inject.Inject
 class ProxySelectorActivity : AppCompatActivity() {
 
   @Inject lateinit var gitSettings: GitSettings
-  @ProxyPreferences @Inject lateinit var proxyPrefs: SharedPreferences
+  @SettingsPreferences @Inject lateinit var proxyPrefs: SharedPreferences
   @Inject lateinit var proxyUtils: ProxyUtils
   private val binding by viewBinding(ActivityProxySelectorBinding::inflate)
 

--- a/app/src/main/java/app/passwordstore/ui/settings/RepositorySettings.kt
+++ b/app/src/main/java/app/passwordstore/ui/settings/RepositorySettings.kt
@@ -134,6 +134,8 @@ class RepositorySettings(private val activity: FragmentActivity) : SettingsProvi
           requestRebind()
         }
         onClick {
+          encryptedPreferences.edit { remove(PreferenceKeys.SSH_KEY_LOCAL_PASSPHRASE) }
+          encryptedPreferences.edit { remove(PreferenceKeys.HTTPS_PASSWORD) }
           updatePref()
           true
         }

--- a/app/src/main/java/app/passwordstore/ui/settings/RepositorySettings.kt
+++ b/app/src/main/java/app/passwordstore/ui/settings/RepositorySettings.kt
@@ -6,7 +6,6 @@
 package app.passwordstore.ui.settings
 
 import android.content.Intent
-import android.content.SharedPreferences
 import android.content.pm.ShortcutManager
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.core.content.edit
@@ -14,7 +13,6 @@ import androidx.core.content.getSystemService
 import androidx.fragment.app.FragmentActivity
 import app.passwordstore.R
 import app.passwordstore.data.repo.PasswordRepository
-import app.passwordstore.injection.prefs.GitPreferences
 import app.passwordstore.ui.git.config.GitConfigActivity
 import app.passwordstore.ui.git.config.GitServerConfigActivity
 import app.passwordstore.ui.proxy.ProxySelectorActivity
@@ -59,7 +57,6 @@ class RepositorySettings(private val activity: FragmentActivity) : SettingsProvi
   private var showSshKeyPref: Preference? = null
 
   override fun provideSettings(builder: PreferenceScreen.Builder) {
-    val encryptedPreferences = hiltEntryPoint.encryptedPreferences()
     val gitSettings = hiltEntryPoint.gitSettings()
 
     builder.apply {
@@ -117,30 +114,6 @@ class RepositorySettings(private val activity: FragmentActivity) : SettingsProvi
             true
           }
         }
-      pref(PreferenceKeys.CLEAR_SAVED_PASS) {
-        fun Preference.updatePref() {
-          val sshPass = encryptedPreferences.getString(PreferenceKeys.SSH_KEY_LOCAL_PASSPHRASE)
-          val httpsPass = encryptedPreferences.getString(PreferenceKeys.HTTPS_PASSWORD)
-          if (sshPass == null && httpsPass == null) {
-            visible = false
-            return
-          }
-          titleRes =
-            when {
-              httpsPass != null -> R.string.clear_saved_passphrase_https
-              else -> R.string.clear_saved_passphrase_ssh
-            }
-          visible = true
-          requestRebind()
-        }
-        onClick {
-          encryptedPreferences.edit { remove(PreferenceKeys.SSH_KEY_LOCAL_PASSPHRASE) }
-          encryptedPreferences.edit { remove(PreferenceKeys.HTTPS_PASSWORD) }
-          updatePref()
-          true
-        }
-        updatePref()
-      }
       pref(PreferenceKeys.SSH_OPENKEYSTORE_CLEAR_KEY_ID) {
         titleRes = R.string.pref_title_openkeystore_clear_keyid
         visible =
@@ -192,7 +165,5 @@ class RepositorySettings(private val activity: FragmentActivity) : SettingsProvi
   @InstallIn(SingletonComponent::class)
   interface RepositorySettingsEntryPoint {
     fun gitSettings(): GitSettings
-
-    @GitPreferences fun encryptedPreferences(): SharedPreferences
   }
 }

--- a/app/src/main/java/app/passwordstore/ui/sshkeygen/SshKeyGenActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/sshkeygen/SshKeyGenActivity.kt
@@ -4,19 +4,16 @@
  */
 package app.passwordstore.ui.sshkeygen
 
-import android.content.SharedPreferences
 import android.os.Bundle
 import android.security.keystore.UserNotAuthenticatedException
 import android.view.MenuItem
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.edit
 import androidx.core.content.getSystemService
 import androidx.lifecycle.lifecycleScope
 import app.passwordstore.R
 import app.passwordstore.databinding.ActivitySshKeygenBinding
-import app.passwordstore.injection.prefs.GitPreferences
 import app.passwordstore.util.auth.BiometricAuthenticator
 import app.passwordstore.util.auth.BiometricAuthenticator.Result
 import app.passwordstore.util.coroutines.DispatcherProvider
@@ -50,7 +47,6 @@ class SshKeyGenActivity : AppCompatActivity() {
 
   private var keyGenType = KeyGenType.Ecdsa
   private val binding by viewBinding(ActivitySshKeygenBinding::inflate)
-  @GitPreferences @Inject lateinit var gitPrefs: SharedPreferences
   @Inject lateinit var dispatcherProvider: DispatcherProvider
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -140,7 +136,6 @@ class SshKeyGenActivity : AppCompatActivity() {
         keyGenType.generateKey(requireAuthentication)
       }
     }
-    gitPrefs.edit { remove("ssh_key_local_passphrase") }
     binding.generate.apply {
       text = getString(R.string.ssh_keygen_generate)
       isEnabled = true

--- a/app/src/main/java/app/passwordstore/util/extensions/AndroidExtensions.kt
+++ b/app/src/main/java/app/passwordstore/util/extensions/AndroidExtensions.kt
@@ -25,8 +25,6 @@ import androidx.compose.ui.Modifier
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.fragment.app.FragmentActivity
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
 import app.passwordstore.BuildConfig
 import app.passwordstore.R
 import app.passwordstore.data.repo.PasswordRepository
@@ -43,22 +41,6 @@ val Context.autofillManager: AutofillManager?
 /** Get an instance of [ClipboardManager] */
 val Context.clipboard
   get() = getSystemService<ClipboardManager>()
-
-/** Wrapper for [getEncryptedPrefs] to avoid open-coding the file name at each call site */
-fun Context.getEncryptedGitPrefs() = getEncryptedPrefs("git_operation")
-
-/** Get an instance of [EncryptedSharedPreferences] with the given [fileName] */
-private fun Context.getEncryptedPrefs(fileName: String): SharedPreferences {
-  val masterKeyAlias =
-    MasterKey.Builder(applicationContext).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build()
-  return EncryptedSharedPreferences.create(
-    applicationContext,
-    fileName,
-    masterKeyAlias,
-    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
-  )
-}
 
 /** Get an instance of [KeyguardManager] */
 val Context.keyguardManager: KeyguardManager

--- a/app/src/main/java/app/passwordstore/util/features/Feature.kt
+++ b/app/src/main/java/app/passwordstore/util/features/Feature.kt
@@ -14,5 +14,5 @@ enum class Feature(
 ) {
 
   /** Opt into a cache layer for PGP passphrases. */
-  EnablePGPPassphraseCache(false, "enable_gpg_passphrase_cache")
+  //EnablePGPPassphraseCache(false, "enable_gpg_passphrase_cache")
 }

--- a/app/src/main/java/app/passwordstore/util/features/Feature.kt
+++ b/app/src/main/java/app/passwordstore/util/features/Feature.kt
@@ -14,5 +14,5 @@ enum class Feature(
 ) {
 
   /** Opt into a cache layer for PGP passphrases. */
-  //EnablePGPPassphraseCache(false, "enable_gpg_passphrase_cache")
+  // EnablePGPPassphraseCache(false, "enable_gpg_passphrase_cache")
 }

--- a/app/src/main/java/app/passwordstore/util/git/sshj/SshKey.kt
+++ b/app/src/main/java/app/passwordstore/util/git/sshj/SshKey.kt
@@ -18,7 +18,6 @@ import androidx.security.crypto.EncryptedFile
 import androidx.security.crypto.MasterKey
 import app.passwordstore.Application
 import app.passwordstore.R
-import app.passwordstore.util.extensions.getEncryptedGitPrefs
 import app.passwordstore.util.extensions.getString
 import app.passwordstore.util.extensions.sharedPrefs
 import app.passwordstore.util.extensions.unsafeLazy
@@ -184,7 +183,6 @@ object SshKey {
     if (publicKeyFile.isFile) {
       publicKeyFile.delete()
     }
-    context.getEncryptedGitPrefs().edit { remove(PreferenceKeys.SSH_KEY_LOCAL_PASSPHRASE) }
     type = null
   }
 

--- a/app/src/main/java/app/passwordstore/util/git/sshj/SshjSessionFactory.kt
+++ b/app/src/main/java/app/passwordstore/util/git/sshj/SshjSessionFactory.kt
@@ -53,7 +53,7 @@ abstract class InteractivePasswordFinder(private val dispatcherProvider: Dispatc
 
   private var isRetry = false
 
-  abstract fun askForPassword(cont: Continuation<String?>, isRetry: Boolean)
+  abstract fun askForPassword(cont: Continuation<CharArray?>, isRetry: Boolean)
 
   override fun reqPassword(resource: Resource<*>?): CharArray {
     val password =
@@ -61,7 +61,7 @@ abstract class InteractivePasswordFinder(private val dispatcherProvider: Dispatc
         suspendCoroutine { cont -> askForPassword(cont, isRetry) }
       }
     isRetry = true
-    return password?.toCharArray() ?: throw SSHException(DisconnectReason.AUTH_CANCELLED_BY_USER)
+    return password ?: throw SSHException(DisconnectReason.AUTH_CANCELLED_BY_USER)
   }
 
   final override fun shouldRetry(resource: Resource<*>?) = true

--- a/app/src/main/java/app/passwordstore/util/settings/GitSettings.kt
+++ b/app/src/main/java/app/passwordstore/util/settings/GitSettings.kt
@@ -4,12 +4,11 @@
  */
 package app.passwordstore.util.settings
 
+// import app.passwordstore.injection.prefs.ProxyPreferences
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import app.passwordstore.data.repo.PasswordRepository
 import app.passwordstore.injection.context.FilesDirPath
-import app.passwordstore.injection.prefs.GitPreferences
-import app.passwordstore.injection.prefs.ProxyPreferences
 import app.passwordstore.injection.prefs.SettingsPreferences
 import app.passwordstore.util.extensions.getString
 import com.github.michaelbull.result.getOrElse
@@ -51,8 +50,6 @@ class GitSettings
 @Inject
 constructor(
   @SettingsPreferences private val settings: SharedPreferences,
-  @GitPreferences private val encryptedSettings: SharedPreferences,
-  @ProxyPreferences private val proxySettings: SharedPreferences,
   @FilesDirPath private val filesDirPath: String,
 ) {
 
@@ -73,7 +70,6 @@ constructor(
       // When the server changes, remote password, multiplexing support and host key file
       // should be deleted/reset.
       useMultiplexing = true
-      encryptedSettings.edit { remove(PreferenceKeys.HTTPS_PASSWORD) }
       clearSavedHostKey()
     }
 
@@ -96,27 +92,31 @@ constructor(
     }
 
   var proxyHost
-    get() = proxySettings.getString(PreferenceKeys.PROXY_HOST)
+    // get() = settings.getString(PreferenceKeys.PROXY_HOST)
+    get() = settings.getString(PreferenceKeys.PROXY_HOST)
     set(value) {
-      proxySettings.edit { putString(PreferenceKeys.PROXY_HOST, value) }
+      // settings.edit { putString(PreferenceKeys.PROXY_HOST, value) }
+      settings.edit { putString(PreferenceKeys.PROXY_HOST, value) }
     }
 
   var proxyPort
-    get() = proxySettings.getInt(PreferenceKeys.PROXY_PORT, -1)
+    // get() = settings.getInt(PreferenceKeys.PROXY_PORT, -1)
+    get() = settings.getInt(PreferenceKeys.PROXY_PORT, -1)
     set(value) {
-      proxySettings.edit { putInt(PreferenceKeys.PROXY_PORT, value) }
+      // settings.edit { putInt(PreferenceKeys.PROXY_PORT, value) }
+      settings.edit { putInt(PreferenceKeys.PROXY_PORT, value) }
     }
 
   var proxyUsername
     get() = settings.getString(PreferenceKeys.PROXY_USERNAME)
     set(value) {
-      proxySettings.edit { putString(PreferenceKeys.PROXY_USERNAME, value) }
+      settings.edit { putString(PreferenceKeys.PROXY_USERNAME, value) }
     }
 
   var proxyPassword
-    get() = proxySettings.getString(PreferenceKeys.PROXY_PASSWORD)
+    get() = settings.getString(PreferenceKeys.PROXY_PASSWORD)
     set(value) {
-      proxySettings.edit { putString(PreferenceKeys.PROXY_PASSWORD, value) }
+      settings.edit { putString(PreferenceKeys.PROXY_PASSWORD, value) }
     }
 
   var rebaseOnPull

--- a/app/src/main/java/app/passwordstore/util/settings/Migrations.kt
+++ b/app/src/main/java/app/passwordstore/util/settings/Migrations.kt
@@ -6,8 +6,11 @@
 
 package app.passwordstore.util.settings
 
+import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import app.passwordstore.util.extensions.getString
 import app.passwordstore.util.git.sshj.SshKey
 import com.github.michaelbull.result.get
@@ -20,7 +23,13 @@ import logcat.logcat
 
 private const val TAG = "Migrations"
 
-fun runMigrations(filesDirPath: String, sharedPrefs: SharedPreferences, gitSettings: GitSettings) {
+fun runMigrations(
+  filesDirPath: String,
+  sharedPrefs: SharedPreferences,
+  gitSettings: GitSettings,
+  context: Context,
+  runTest: Boolean = false,
+) {
   migrateToGitUrlBasedConfig(sharedPrefs, gitSettings)
   migrateToHideAll(sharedPrefs)
   migrateToSshKey(filesDirPath, sharedPrefs)
@@ -28,15 +37,68 @@ fun runMigrations(filesDirPath: String, sharedPrefs: SharedPreferences, gitSetti
   migrateToDiceware(sharedPrefs)
   removeExternalStorageProperties(sharedPrefs)
   removeCurrentBranchValue(sharedPrefs)
-  removePersistentPassphraseChache(sharedPrefs)
+  removePersistentCredentialCache(sharedPrefs, context, runTest)
 }
 
-private fun removePersistentPassphraseChache(sharedPrefs: SharedPreferences) {
-  if (!sharedPrefs.contains(PreferenceKeys.CLEAR_PASSPHRASE_CACHE)) {
-    return
+private fun removePersistentCredentialCache(
+  sharedPrefs: SharedPreferences,
+  context: Context,
+  runTest: Boolean,
+) {
+  val gitPrefs = if (runTest) sharedPrefs else createEncryptedPreferences(context, "git_operation")
+  val proxyPrefs = if (runTest) sharedPrefs else createEncryptedPreferences(context, "http_proxy")
+  val pwgenPrefs =
+    if (runTest) sharedPrefs else createEncryptedPreferences(context, "pwgen_preferences")
+
+  if (sharedPrefs.contains(PreferenceKeys.CLEAR_PASSPHRASE_CACHE)) {
+    logcat(TAG, INFO) { "Deleting now unused persistent PGP passphrase cache preference" }
+    sharedPrefs.edit { remove(PreferenceKeys.CLEAR_PASSPHRASE_CACHE) }
   }
-  logcat(TAG, INFO) { "Deleting now unused persistent PGP passphrase cache preference" }
-  sharedPrefs.edit { remove(PreferenceKeys.CLEAR_PASSPHRASE_CACHE) }
+  if (gitPrefs.contains(PreferenceKeys.SSH_KEY_LOCAL_PASSPHRASE)) {
+    logcat(TAG, INFO) { "Wiping cached credential" }
+    gitPrefs.edit { remove(PreferenceKeys.SSH_KEY_LOCAL_PASSPHRASE) }
+  }
+  if (gitPrefs.contains(PreferenceKeys.HTTPS_PASSWORD)) {
+    logcat(TAG, INFO) { "Wiping cached credential" }
+    gitPrefs.edit { remove(PreferenceKeys.HTTPS_PASSWORD) }
+  }
+  var value = proxyPrefs.getString(PreferenceKeys.PROXY_HOST, null)
+  value?.let {
+    logcat(TAG, INFO) { "Moving PreferenceKeys.PROXY_HOST to SharedPreferences" }
+    proxyPrefs.edit { remove(PreferenceKeys.PROXY_HOST) }
+    sharedPrefs.edit { putString(PreferenceKeys.PROXY_HOST, value) }
+  }
+  value = proxyPrefs.getString(PreferenceKeys.PROXY_PORT, null)
+  value?.let {
+    logcat(TAG, INFO) { "Moving PreferenceKeys.PROXY_PORT to SharedPreferences" }
+    proxyPrefs.edit { remove(PreferenceKeys.PROXY_PORT) }
+    sharedPrefs.edit { putString(PreferenceKeys.PROXY_PORT, value) }
+  }
+  value = proxyPrefs.getString(PreferenceKeys.PROXY_USERNAME, null)
+  value?.let {
+    logcat(TAG, INFO) { "Moving PreferenceKeys.PROXY_USERNAME to SharedPreferences" }
+    proxyPrefs.edit { remove(PreferenceKeys.PROXY_USERNAME) }
+    sharedPrefs.edit { putString(PreferenceKeys.PROXY_USERNAME, value) }
+  }
+  val password = proxyPrefs.getString(PreferenceKeys.PROXY_PASSWORD, null)?.toCharArray()
+  password?.let {
+    logcat(TAG, INFO) { "Moving PreferenceKeys.PROXY_PASSWORD to SharedPreferences" }
+    proxyPrefs.edit { remove(PreferenceKeys.PROXY_PASSWORD) }
+    sharedPrefs.edit { putString(PreferenceKeys.PROXY_PASSWORD, String(password)) }
+  }
+  value = pwgenPrefs.getString(PreferenceKeys.DICEWARE_SEPARATOR, null)
+  value?.let {
+    logcat(TAG, INFO) { "Moving PreferenceKeys.DICEWARE_SEPARATOR to SharedPreferences" }
+    pwgenPrefs.edit { remove(PreferenceKeys.DICEWARE_SEPARATOR) }
+    if (runTest) value = "§"
+    sharedPrefs.edit { putString(PreferenceKeys.DICEWARE_SEPARATOR, value) }
+  }
+  value = pwgenPrefs.getString(PreferenceKeys.DICEWARE_LENGTH, null)
+  value?.let {
+    logcat(TAG, INFO) { "Moving PreferenceKeys.DICEWARE_LENGTH to SharedPreferences" }
+    pwgenPrefs.edit { remove(PreferenceKeys.DICEWARE_LENGTH) }
+    sharedPrefs.edit { putString(PreferenceKeys.DICEWARE_LENGTH, value) }
+  }
 }
 
 private fun removeCurrentBranchValue(sharedPrefs: SharedPreferences) {
@@ -166,4 +228,16 @@ private fun removeExternalStorageProperties(prefs: SharedPreferences) {
       remove(PreferenceKeys.GIT_EXTERNAL_REPO)
     }
   }
+}
+
+private fun createEncryptedPreferences(context: Context, fileName: String): SharedPreferences {
+  val masterKeyAlias =
+    MasterKey.Builder(context).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build()
+  return EncryptedSharedPreferences.create(
+    context,
+    fileName,
+    masterKeyAlias,
+    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+  )
 }

--- a/app/src/main/java/app/passwordstore/util/settings/Migrations.kt
+++ b/app/src/main/java/app/passwordstore/util/settings/Migrations.kt
@@ -28,9 +28,18 @@ fun runMigrations(filesDirPath: String, sharedPrefs: SharedPreferences, gitSetti
   migrateToDiceware(sharedPrefs)
   removeExternalStorageProperties(sharedPrefs)
   removeCurrentBranchValue(sharedPrefs)
+  removePersistentPassphraseChache(sharedPrefs)
 }
 
-fun removeCurrentBranchValue(sharedPrefs: SharedPreferences) {
+private fun removePersistentPassphraseChache(sharedPrefs: SharedPreferences) {
+  if (!sharedPrefs.contains(PreferenceKeys.CLEAR_PASSPHRASE_CACHE)) {
+    return
+  }
+  logcat(TAG, INFO) { "Deleting now unused persistent PGP passphrase cache preference" }
+  sharedPrefs.edit { remove(PreferenceKeys.CLEAR_PASSPHRASE_CACHE) }
+}
+
+private fun removeCurrentBranchValue(sharedPrefs: SharedPreferences) {
   if (!sharedPrefs.contains(PreferenceKeys.GIT_BRANCH_NAME)) {
     return
   }

--- a/app/src/main/res/layout/git_credential_layout.xml
+++ b/app/src/main/res/layout/git_credential_layout.xml
@@ -29,14 +29,4 @@
 
     <requestFocus />
   </com.google.android.material.textfield.TextInputLayout>
-
-  <com.google.android.material.checkbox.MaterialCheckBox
-    android:id="@+id/git_auth_remember_credential"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:text="@string/git_operation_remember_passphrase"
-    app:checkedState="checked"
-    app:layout_constraintRight_toRightOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@+id/git_auth_passphrase_layout" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -236,9 +236,6 @@
   <!-- Autofill -->
   <string name="ssh_key_does_not_exist">Der private SSH-Schlüssel konnte nicht geöffnet werden. Bitte überprüfen Sie, ob die Datei existiert.</string>
   <string name="new_password_title">Neues Passwort</string>
-  <string name="clear_saved_passphrase_ssh">Gespeicherte Passphrase für lokalen SSH-Schlüssel löschen</string>
-  <string name="clear_saved_passphrase_https">Gespeichertes HTTPS-Passwort löschen</string>
-  <string name="git_operation_remember_passphrase">Schlüsselpasswort merken</string>
   <string name="git_tools">Hilfsmittel</string>
   <string name="abort_rebase">Rebase abbrechen und neuen Branch pushen</string>
   <string name="reset_to_remote">Hard Reset auf Remote-Branch</string>
@@ -288,7 +285,6 @@
   <string name="pref_debug_logging_title">Debug-Logging</string>
   <string name="preference_default_username_summary">Wenn Autofill den Benutzernamen nicht aus der Passwortdatei oder dem Ordner herleiten kann, wird der hier festgelegte Wert verwendet.</string>
   <string name="preference_default_username_title">Standard-Benutzername</string>
-  <string name="git_operation_remember_password">Passwort merken</string>
   <string name="git_operation_hint_password">Passwort</string>
   <string name="preference_custom_public_suffixes_title">Benutzerdefinierte Domains</string>
   <string name="preference_custom_public_suffixes_summary">Autofill wird Subdomains dieser Domains unterscheiden.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -200,9 +200,6 @@
   <!-- Autofill -->
   <string name="ssh_key_does_not_exist">Impossible d\'ouvrir la clef ssh, merci de vérifier que le ficher existe</string>
   <string name="new_password_title">Nouveau mot de passe</string>
-  <string name="clear_saved_passphrase_ssh">Effacer le mot de passe enregistrée pour la clé SSH locale</string>
-  <string name="clear_saved_passphrase_https">Effacer le mot de passe HTTPS enregistré</string>
-  <string name="git_operation_remember_passphrase">Se rappeler de la phrase secrète dans la configuration de l\'application (peu sûr)</string>
   <string name="git_tools">Utilitaires</string>
   <string name="abort_rebase">Annuler rebase et pousser une nouvelle branche</string>
   <string name="reset_to_remote">Réinitialisation dure de la branche distante</string>
@@ -251,7 +248,6 @@
   <string name="pref_debug_logging_title">Journal de débogage</string>
   <string name="preference_default_username_summary">Si le remplissage automatique est incapable de déterminer un nom d\'utilisateur à partir de votre fichier de mot de passe ou de la structure de répertoire, il utilisera la valeur spécifiée ici</string>
   <string name="preference_default_username_title">Nom d\'utilisateur par défaut</string>
-  <string name="git_operation_remember_password">Mémoriser le mot de passe</string>
   <string name="git_operation_hint_password">Mot de passe</string>
   <string name="preference_custom_public_suffixes_title">Domaines personnalisés</string>
   <string name="preference_custom_public_suffixes_summary">Le remplissage automatique distinguera les sous-domaines de ces domaines</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -209,9 +209,6 @@ a app desde unha fonte de confianza, como a Play Store, Amazon Appstore, F-Droid
   <!-- Autofill -->
   <string name="ssh_key_does_not_exist">Non se pode abrir a chave privada ssh, comproba que existe tal ficheiro</string>
   <string name="new_password_title">Novo contrasinal</string>
-  <string name="clear_saved_passphrase_ssh">Baleirar a frase de paso gardada para a chave SSH local</string>
-  <string name="clear_saved_passphrase_https">Baleirar contrasinal HTTPS gardado</string>
-  <string name="git_operation_remember_passphrase">Lembrar frase de paso da chave</string>
   <string name="git_tools">Ferramentas</string>
   <string name="abort_rebase">Abortar rebase e push a unha nova rama</string>
   <string name="reset_to_remote">Hard reset na rama remota</string>
@@ -260,7 +257,6 @@ a app desde unha fonte de confianza, como a Play Store, Amazon Appstore, F-Droid
   <string name="pref_debug_logging_title">Rexistro de problemas</string>
   <string name="preference_default_username_summary">Se Autocompletado non é quen de determinar o identificador no ficheiro do contrasinal ou estructura de directorios, utilizará o valor indicado aquí</string>
   <string name="preference_default_username_title">Identificador por defecto</string>
-  <string name="git_operation_remember_password">Lembrar contrasinal</string>
   <string name="git_operation_hint_password">Contrasinal</string>
   <string name="preference_custom_public_suffixes_title">Dominios personalizados</string>
   <string name="preference_custom_public_suffixes_summary">Autofill distinguirá entre subdominios nestes dominios</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -195,9 +195,6 @@
   <!-- Autofill -->
   <string name="ssh_key_does_not_exist">Impossibile aprire la chiave privata ssh, sei pregato di controllare che il file esista</string>
   <string name="new_password_title">Nuova password</string>
-  <string name="clear_saved_passphrase_ssh">Cancella la frase segreta salvata per la chiave SSH locale</string>
-  <string name="clear_saved_passphrase_https">Cancella la password HTTPS salvata</string>
-  <string name="git_operation_remember_passphrase">Ricorda la frase segreta chiave</string>
   <string name="git_tools">Utilità</string>
   <string name="abort_rebase">Interrompi il rebase e premi nuovo ramo</string>
   <string name="reset_to_remote">Hard reset a ramo remoto</string>
@@ -246,7 +243,6 @@
   <string name="pref_debug_logging_title">Registrazione di debug</string>
   <string name="preference_default_username_summary">Se l\'autocompletamento non può determinare un nome utente dal tuo file della password o la struttura della directory, userà il valore qui specificato</string>
   <string name="preference_default_username_title">Nome utente predefinito</string>
-  <string name="git_operation_remember_password">Ricorda password</string>
   <string name="git_operation_hint_password">Password</string>
   <string name="preference_custom_public_suffixes_title">Domini personalizzati</string>
   <string name="preference_custom_public_suffixes_summary">L\'auto-completamento distinguerà i sottodomini di questi domini</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -206,9 +206,6 @@
   <!-- Autofill -->
   <string name="ssh_key_does_not_exist">SSH 개인 키를 열 수 없습니다. 파일이 존재하는지 확인하세요</string>
   <string name="new_password_title">새 암호</string>
-  <string name="clear_saved_passphrase_ssh">로컬 SSH 키의 저장된 비밀번호 지우기</string>
-  <string name="clear_saved_passphrase_https">저장된 HTTPS 비밀번호 지우기</string>
-  <string name="git_operation_remember_passphrase">키 암호 기억하기</string>
   <string name="git_tools">유틸리티</string>
   <string name="abort_rebase">리베이스 중단 및 새 브랜치 푸시</string>
   <string name="reset_to_remote">원격 지점으로 하드 리셋</string>
@@ -259,7 +256,6 @@ username@example.com:…</string>
   <string name="pref_debug_logging_title">디버그 로깅</string>
   <string name="preference_default_username_summary">비밀번호 파일 또는 디렉터리 구조에서 사용자 이름을 확인할 수 없는 경우 여기에 지정된 값으로 자동 완성 합니다</string>
   <string name="preference_default_username_title">기본 사용자 이름</string>
-  <string name="git_operation_remember_password">비밀번호 저장</string>
   <string name="git_operation_hint_password">비밀번호</string>
   <string name="preference_custom_public_suffixes_title">지정 도메인</string>
   <string name="preference_custom_public_suffixes_summary">자동 완성은 다음 도메인의 하위 도메인을 구분합니다.</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -203,9 +203,6 @@
   <!-- Autofill -->
   <string name="ssh_key_does_not_exist">Nie można otworzyć klucza prywatnego ssh, sprawdź czy plik istnieje</string>
   <string name="new_password_title">Nowe hasło</string>
-  <string name="clear_saved_passphrase_ssh">Wyczyść zapisane hasło dla lokalnego klucza SSH</string>
-  <string name="clear_saved_passphrase_https">Wyczyść zapisane hasło HTTPS</string>
-  <string name="git_operation_remember_passphrase">Zapamiętaj hasło klucza</string>
   <string name="git_tools">Narzędzia</string>
   <string name="abort_rebase">Przerwij \"rebase\" i wypchnij nową gałąź</string>
   <string name="reset_to_remote">Twardy reset do zdalnej gałęzi</string>
@@ -254,7 +251,6 @@
   <string name="pref_debug_logging_title">Logowanie w trybie \"debug\"</string>
   <string name="preference_default_username_summary">Jeśli autouzupełnianie nie jest w stanie określić nazwy użytkownika ze struktury pliku hasła lub katalogu, użyje wartości podanej tutaj</string>
   <string name="preference_default_username_title">Domyślna nazwa użytkownika</string>
-  <string name="git_operation_remember_password">Zapamiętaj hasło</string>
   <string name="git_operation_hint_password">Hasło</string>
   <string name="preference_custom_public_suffixes_title">Domeny niestandardowe</string>
   <string name="preference_custom_public_suffixes_summary">Autouzupełnianie rozróżni subdomeny tych domen</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -207,9 +207,6 @@
   <!-- Autofill -->
   <string name="ssh_key_does_not_exist">Não foi possível abrir a chave privada ssh, por favor verifique se o arquivo existe</string>
   <string name="new_password_title">Nova senha</string>
-  <string name="clear_saved_passphrase_ssh">Limpar a frase secreta salva para chave SSH local</string>
-  <string name="clear_saved_passphrase_https">Limpar senha HTTPS salva</string>
-  <string name="git_operation_remember_passphrase">Lembrar senha da chave</string>
   <string name="git_tools">Utilitários</string>
   <string name="abort_rebase">Abortar rebase e realizar push do novo branch</string>
   <string name="reset_to_remote">Hard reset no branch remoto</string>
@@ -258,7 +255,6 @@
   <string name="pref_debug_logging_title">Debug log</string>
   <string name="preference_default_username_summary">Se o preenchimento automático não puder determinar um nome de usuário a partir do seu arquivo de senha ou estrutura de diretório, ele usará o valor especificado aqui</string>
   <string name="preference_default_username_title">Nome padrão</string>
-  <string name="git_operation_remember_password">Lembrar senha</string>
   <string name="git_operation_hint_password">Senha</string>
   <string name="preference_custom_public_suffixes_title">Domínios personalizados</string>
   <string name="preference_custom_public_suffixes_summary">O preenchimento automático distinguirá os subdomínios destes domínios</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -204,9 +204,6 @@
   <!-- Autofill -->
   <string name="ssh_key_does_not_exist">Невозможно открыть приватный ключ ssh, пожалуйста проверьте, что файл существует</string>
   <string name="new_password_title">Новый пароль</string>
-  <string name="clear_saved_passphrase_ssh">Очистить сохраненную кодовую фразу для локального SSH ключа</string>
-  <string name="clear_saved_passphrase_https">Удалить сохраненный пароль HTTPS</string>
-  <string name="git_operation_remember_passphrase">Запомнить кодовую фразу</string>
   <string name="git_tools">Утилиты</string>
   <string name="abort_rebase">Прервать перебазирование и записать изменения в новую ветку</string>
   <string name="reset_to_remote">Полный сброс до состояния удаленной ветки</string>
@@ -255,7 +252,6 @@
   <string name="pref_debug_logging_title">Журнал отладки</string>
   <string name="preference_default_username_summary">Если автозаполнение не сможет определить имя пользователя из файла пароля или структуры каталога, оно будет использовать значение, указанное здесь</string>
   <string name="preference_default_username_title">Имя пользователя по умолчанию</string>
-  <string name="git_operation_remember_password">Запомнить пароль</string>
   <string name="git_operation_hint_password">Пароль</string>
   <string name="preference_custom_public_suffixes_title">Пользовательские домены</string>
   <string name="preference_custom_public_suffixes_summary">Автозаполнение будет разделять поддомены этих доменов</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -212,9 +212,6 @@
   <!-- Autofill -->
   <string name="ssh_key_does_not_exist">无法打开SSH私钥,请检查文件是否存在</string>
   <string name="new_password_title">新密码</string>
-  <string name="clear_saved_passphrase_ssh">清除本地已保存的SSH密钥密码</string>
-  <string name="clear_saved_passphrase_https">清除保存的HTTPS密码</string>
-  <string name="git_operation_remember_passphrase">记住密钥密码</string>
   <string name="git_tools">工具</string>
   <string name="abort_rebase">放弃变更并推送新的分支</string>
   <string name="reset_to_remote">强制重置远程分支</string>
@@ -262,7 +259,6 @@
   <string name="pref_debug_logging_title">调试日志</string>
   <string name="preference_default_username_summary">如果自动填充无法从您的密码文件或目录结构中确定用户名,它将使用此处指定的值</string>
   <string name="preference_default_username_title">默认用户名</string>
-  <string name="git_operation_remember_password">记住密码</string>
   <string name="git_operation_hint_password">密码</string>
   <string name="preference_custom_public_suffixes_title">自定义域名</string>
   <string name="preference_custom_public_suffixes_summary">自动填充将区分这些域名的子域名</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -237,9 +237,6 @@
   <!-- Autofill -->
   <string name="ssh_key_does_not_exist">Unable to open the ssh private key, please check that the file exists</string>
   <string name="new_password_title">New password</string>
-  <string name="clear_saved_passphrase_ssh">Clear saved passphrase for local SSH key</string>
-  <string name="clear_saved_passphrase_https">Clear saved HTTPS password</string>
-  <string name="git_operation_remember_passphrase">Remember key passphrase</string>
   <string name="git_tools">Utilities</string>
   <string name="abort_rebase">Abort rebase and push new branch</string>
   <string name="reset_to_remote">Hard reset to remote branch</string>
@@ -289,7 +286,6 @@
   <string name="pref_debug_logging_title">Debug logging</string>
   <string name="preference_default_username_summary">If Autofill is unable to determine a username from your password file or directory structure, it will use the value specified here</string>
   <string name="preference_default_username_title">Default username</string>
-  <string name="git_operation_remember_password">Remember password</string>
   <string name="git_operation_hint_password">Password</string>
   <string name="preference_custom_public_suffixes_title">Custom domains</string>
   <string name="preference_custom_public_suffixes_summary">Autofill will distinguish subdomains of these domains</string>

--- a/app/src/test/java/app/passwordstore/util/settings/MigrationsTest.kt
+++ b/app/src/test/java/app/passwordstore/util/settings/MigrationsTest.kt
@@ -27,16 +27,17 @@ class MigrationsTest {
   private lateinit var context: Context
   private lateinit var filesDir: String
   private lateinit var sharedPrefs: SharedPreferences
-  private lateinit var encryptedSharedPreferences: SharedPreferences
-  private lateinit var proxySharedPreferences: SharedPreferences
+
+  //  private lateinit var encryptedSharedPreferences: SharedPreferences
+  //  private lateinit var proxySharedPreferences: SharedPreferences
 
   @BeforeTest
   fun setup() {
     context = SPMockBuilder().createContext()
     filesDir = tempFolder.root.path
     sharedPrefs = SPMockBuilder().createSharedPreferences()
-    encryptedSharedPreferences = SPMockBuilder().createSharedPreferences()
-    proxySharedPreferences = SPMockBuilder().createSharedPreferences()
+    //    encryptedSharedPreferences = SPMockBuilder().createSharedPreferences()
+    //    proxySharedPreferences =     SPMockBuilder().createSharedPreferences()
   }
 
   private fun checkOldKeysAreRemoved() =
@@ -58,11 +59,7 @@ class MigrationsTest {
       putString(PreferenceKeys.GIT_REMOTE_PROTOCOL, Protocol.Ssh.pref)
       putString(PreferenceKeys.GIT_REMOTE_AUTH, AuthMode.Password.pref)
     }
-    runMigrations(
-      filesDir,
-      sharedPrefs,
-      GitSettings(sharedPrefs, encryptedSharedPreferences, proxySharedPreferences, filesDir),
-    )
+    runMigrations(filesDir, sharedPrefs, GitSettings(sharedPrefs, filesDir), context, true)
     checkOldKeysAreRemoved()
     assertEquals(
       sharedPrefs.getString(PreferenceKeys.GIT_REMOTE_URL),
@@ -79,11 +76,7 @@ class MigrationsTest {
       putString(PreferenceKeys.GIT_REMOTE_PROTOCOL, Protocol.Ssh.pref)
       putString(PreferenceKeys.GIT_REMOTE_AUTH, AuthMode.SshKey.pref)
     }
-    runMigrations(
-      filesDir,
-      sharedPrefs,
-      GitSettings(sharedPrefs, encryptedSharedPreferences, proxySharedPreferences, filesDir),
-    )
+    runMigrations(filesDir, sharedPrefs, GitSettings(sharedPrefs, filesDir), context, true)
     checkOldKeysAreRemoved()
     assertEquals(
       sharedPrefs.getString(PreferenceKeys.GIT_REMOTE_URL),
@@ -100,11 +93,7 @@ class MigrationsTest {
       putString(PreferenceKeys.GIT_REMOTE_PROTOCOL, Protocol.Https.pref)
       putString(PreferenceKeys.GIT_REMOTE_AUTH, AuthMode.None.pref)
     }
-    runMigrations(
-      filesDir,
-      sharedPrefs,
-      GitSettings(sharedPrefs, encryptedSharedPreferences, proxySharedPreferences, filesDir),
-    )
+    runMigrations(filesDir, sharedPrefs, GitSettings(sharedPrefs, filesDir), context, true)
     checkOldKeysAreRemoved()
     assertEquals(
       sharedPrefs.getString(PreferenceKeys.GIT_REMOTE_URL),
@@ -114,11 +103,7 @@ class MigrationsTest {
 
   @Test
   fun verifyHiddenFoldersMigrationIfDisabled() {
-    runMigrations(
-      filesDir,
-      sharedPrefs,
-      GitSettings(sharedPrefs, encryptedSharedPreferences, proxySharedPreferences, filesDir),
-    )
+    runMigrations(filesDir, sharedPrefs, GitSettings(sharedPrefs, filesDir), context, true)
     assertEquals(true, sharedPrefs.getBoolean(PreferenceKeys.SHOW_HIDDEN_FOLDERS, true))
     assertEquals(false, sharedPrefs.getBoolean(PreferenceKeys.SHOW_HIDDEN_CONTENTS, false))
   }
@@ -126,11 +111,7 @@ class MigrationsTest {
   @Test
   fun verifyHiddenFoldersMigrationIfEnabled() {
     sharedPrefs.edit { putBoolean(PreferenceKeys.SHOW_HIDDEN_FOLDERS, true) }
-    runMigrations(
-      filesDir,
-      sharedPrefs,
-      GitSettings(sharedPrefs, encryptedSharedPreferences, proxySharedPreferences, filesDir),
-    )
+    runMigrations(filesDir, sharedPrefs, GitSettings(sharedPrefs, filesDir), context, true)
     assertEquals(false, sharedPrefs.getBoolean(PreferenceKeys.SHOW_HIDDEN_FOLDERS, false))
     assertEquals(true, sharedPrefs.getBoolean(PreferenceKeys.SHOW_HIDDEN_CONTENTS, false))
   }
@@ -138,11 +119,7 @@ class MigrationsTest {
   @Test
   fun verifyClearClipboardHistoryMigration() {
     sharedPrefs.edit { putBoolean(PreferenceKeys.CLEAR_CLIPBOARD_20X, true) }
-    runMigrations(
-      filesDir,
-      sharedPrefs,
-      GitSettings(sharedPrefs, encryptedSharedPreferences, proxySharedPreferences, filesDir),
-    )
+    runMigrations(filesDir, sharedPrefs, GitSettings(sharedPrefs, filesDir), context, true)
     assertEquals(true, sharedPrefs.getBoolean(PreferenceKeys.CLEAR_CLIPBOARD_HISTORY, false))
     assertFalse(sharedPrefs.contains(PreferenceKeys.CLEAR_CLIPBOARD_20X))
   }
@@ -150,22 +127,14 @@ class MigrationsTest {
   @Test
   fun verifyClassicPasswordGeneratorMigration() {
     sharedPrefs.edit { putString(PreferenceKeys.PREF_KEY_PWGEN_TYPE, "classic") }
-    runMigrations(
-      filesDir,
-      sharedPrefs,
-      GitSettings(sharedPrefs, encryptedSharedPreferences, proxySharedPreferences, filesDir),
-    )
+    runMigrations(filesDir, sharedPrefs, GitSettings(sharedPrefs, filesDir), context, true)
     assertEquals("classic", sharedPrefs.getString(PreferenceKeys.PREF_KEY_PWGEN_TYPE))
   }
 
   @Test
   fun verifyXkPasswdPasswordGeneratorMigration() {
     sharedPrefs.edit { putString(PreferenceKeys.PREF_KEY_PWGEN_TYPE, "xkpasswd") }
-    runMigrations(
-      filesDir,
-      sharedPrefs,
-      GitSettings(sharedPrefs, encryptedSharedPreferences, proxySharedPreferences, filesDir),
-    )
+    runMigrations(filesDir, sharedPrefs, GitSettings(sharedPrefs, filesDir), context, true)
     assertEquals("diceware", sharedPrefs.getString(PreferenceKeys.PREF_KEY_PWGEN_TYPE))
   }
 
@@ -175,13 +144,22 @@ class MigrationsTest {
       putBoolean(PreferenceKeys.GIT_EXTERNAL, true)
       putString(PreferenceKeys.GIT_EXTERNAL_REPO, "/sdcard/")
     }
-    runMigrations(
-      filesDir,
-      sharedPrefs,
-      GitSettings(sharedPrefs, encryptedSharedPreferences, proxySharedPreferences, filesDir),
-    )
+    runMigrations(filesDir, sharedPrefs, GitSettings(sharedPrefs, filesDir), context, true)
     assertFalse { sharedPrefs.contains(PreferenceKeys.GIT_EXTERNAL) }
     assertFalse { sharedPrefs.contains(PreferenceKeys.GIT_EXTERNAL_REPO) }
     assertTrue { sharedPrefs.getBoolean(PreferenceKeys.GIT_EXTERNAL_MIGRATED, false) }
+  }
+
+  @Test
+  fun verifyPersistentCredentialCache() {
+    sharedPrefs.edit {
+      putBoolean(PreferenceKeys.CLEAR_PASSPHRASE_CACHE, true)
+      putString(PreferenceKeys.SSH_KEY_LOCAL_PASSPHRASE, "my secret local ssh key passphrase")
+      putString(PreferenceKeys.DICEWARE_SEPARATOR, "#")
+    }
+    runMigrations(filesDir, sharedPrefs, GitSettings(sharedPrefs, filesDir), context, true)
+    assertFalse { sharedPrefs.contains(PreferenceKeys.CLEAR_PASSPHRASE_CACHE) }
+    assertFalse { sharedPrefs.contains(PreferenceKeys.SSH_KEY_LOCAL_PASSPHRASE) }
+    assertEquals(sharedPrefs.getString(PreferenceKeys.DICEWARE_SEPARATOR), "§")
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,7 @@ build-semver = "com.github.zafarkhaja:java-semver:0.10.2"
 build-sentry = "io.sentry.android.gradle:io.sentry.android.gradle.gradle.plugin:4.13.0"
 build-spotless = "com.diffplug.spotless:spotless-plugin-gradle:7.0.0.BETA4"
 build-vcu = "nl.littlerobots.version-catalog-update:nl.littlerobots.version-catalog-update.gradle.plugin:0.8.5"
-compose-bom = "androidx.compose:compose-bom:2024.10.01"
+compose-bom = "androidx.compose:compose-bom:2024.11.00"
 compose-foundation-core = { module = "androidx.compose.foundation:foundation" }
 compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout" }
 compose-material3 = { module = "androidx.compose.material3:material3" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,7 +40,7 @@ pluginManagement {
 
 plugins {
   id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
-  id("com.gradle.develocity") version "3.18.1"
+  id("com.gradle.develocity") version "3.18.2"
 }
 
 develocity {


### PR DESCRIPTION
This PR removes persistent caching of the passphrase for unlocking the local SSH key and of the SSH server password which is based on `EncryptedSharedPreferences` and which was marked deprecated by Google. From now on, they are kept in memory (in a `CharArray`) for the lifetime of the APS process and thus have to be re-entered when syncing the password database after a device or app restart. The HTTP proxy username & password, which are less critical, are moved to SharedPreferences as a persistent setting, so are the diceware separator character and word number. They are still local to the app, sufficiently encrypted and thus invisible for other users and apps without root-access.