### PR TITLE
remove dependency on deprecated androidx.security.crypto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ All notable changes to this project will be documented in this file.
 -   Using the `git://` protocol in the server URL now presents an explicit discouragement rather than a generic error
 -   Encrypted data is no longer ASCII armored, bringing it in line with `pass`
 -   Changing password generator parameters now automatically updates the password without needing to press the 'Generate' button again
+-   **BREAKING** The option for generating the SSH key pair in the Ed25519 format was removed from APS. It relied on the `androidx.security:security-crypto` library to store the private key file in an encrypted fashion in the application's the hidden directory. Use one of Android KeyStore native RSA or ECDSA key format options when generating the SSH key pair. Alternatively, an externally generated SSH private key can be imported into the app. Imported SSH private keys can be in any format, including Ed25519, but they should be secured with a passphrase.
+
 -   The app UI was reskinned to match Google's Material You guidelines
 -   Using HTTPS without authentication is now fully supported, and no longer asks for a username
 -   Enabling 'Show hidden files and folders' no longer shows Git-related files and folders

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Download
 
-Latest [snapshot build (APK)](https://github.com/agrahn/Android-Password-Store/releases/tag/latest).
+Latest [snapshot build (APK)](https://github.com/agrahn/Android-Password-Store/releases/tag/latest) of this fork.
 
 ## Documentation
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,7 +70,6 @@ dependencies {
   implementation(libs.aps.sublimeFuzzy)
   implementation(libs.aps.zxingAndroidEmbedded)
 
-  implementation(libs.thirdparty.eddsa)
   implementation(libs.thirdparty.fastscroll)
   implementation(libs.thirdparty.flowbinding.android)
   implementation(libs.thirdparty.jgit) {

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -23,39 +23,6 @@
     </issue>
 
     <issue
-        id="RawDispatchersUse"
-        message="Use SlackDispatchers."
-        errorLine1="    withContext(Dispatchers.IO) {"
-        errorLine2="                ~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/app/passwordstore/util/git/sshj/SshKey.kt"
-            line="238"
-            column="17"/>
-    </issue>
-
-    <issue
-        id="RawDispatchersUse"
-        message="Use SlackDispatchers."
-        errorLine1="    withContext(Dispatchers.IO) {"
-        errorLine2="                ~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/app/passwordstore/util/git/sshj/SshKey.kt"
-            line="247"
-            column="17"/>
-    </issue>
-
-    <issue
-        id="RawDispatchersUse"
-        message="Use SlackDispatchers."
-        errorLine1="    withContext(Dispatchers.IO) {"
-        errorLine2="                ~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/app/passwordstore/util/git/sshj/SshKey.kt"
-            line="259"
-            column="17"/>
-    </issue>
-
-    <issue
         id="DenyListedApi"
         message="Use Context#getDrawableCompat() instead"
         errorLine1="                ContextCompat.getDrawable(itemView.context, R.drawable.ic_content_copy)"

--- a/app/src/main/java/app/passwordstore/ui/sshkeygen/SshKeyGenActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/sshkeygen/SshKeyGenActivity.kt
@@ -37,9 +37,6 @@ private enum class KeyGenType(val generateKey: suspend (requireAuthentication: B
   Ecdsa({ requireAuthentication ->
     SshKey.generateKeystoreNativeKey(SshKey.Algorithm.Ecdsa, requireAuthentication)
   }),
-  Ed25519({ requireAuthentication ->
-    SshKey.generateKeystoreWrappedEd25519Key(requireAuthentication)
-  }),
 }
 
 @AndroidEntryPoint
@@ -78,14 +75,12 @@ class SshKeyGenActivity : AppCompatActivity() {
         if (isChecked) {
           keyGenType =
             when (checkedId) {
-              R.id.key_type_ed25519 -> KeyGenType.Ed25519
               R.id.key_type_ecdsa -> KeyGenType.Ecdsa
               R.id.key_type_rsa -> KeyGenType.Rsa
               else -> throw IllegalStateException("Impossible key type selection")
             }
           keyTypeExplanation.setText(
             when (keyGenType) {
-              KeyGenType.Ed25519 -> R.string.ssh_keygen_explanation_ed25519
               KeyGenType.Ecdsa -> R.string.ssh_keygen_explanation_ecdsa
               KeyGenType.Rsa -> R.string.ssh_keygen_explanation_rsa
             }

--- a/app/src/main/res/layout/activity_ssh_keygen.xml
+++ b/app/src/main/res/layout/activity_ssh_keygen.xml
@@ -37,13 +37,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/ssh_keygen_label_ecdsa" />
-
-      <com.google.android.material.button.MaterialButton
-        android:id="@+id/key_type_ed25519"
-        style="?attr/materialButtonOutlinedStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/ssh_keygen_label_ed25519" />
     </com.google.android.material.button.MaterialButtonToggleGroup>
 
     <androidx.appcompat.widget.AppCompatTextView

--- a/app/src/main/res/layout/dialog_password_entry.xml
+++ b/app/src/main/res/layout/dialog_password_entry.xml
@@ -14,7 +14,7 @@
     android:id="@+id/password_field"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:hint="@string/password"
+    android:hint="@string/password_input"
     app:endIconMode="password_toggle"
     app:hintAnimationEnabled="true"
     app:hintEnabled="true">

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -167,10 +167,8 @@
   <string name="ssh_keygen_require_authentication">Mit Anmeldedaten für Bildschirmsperre schützen</string>
 
 
-
   <string name="ssh_keygen_explanation_rsa"><b>RSA (3072 Bit)</b>\nWird von allen Servern unterstützt, allerdings ist die Authentifizierung recht langsam.</string>
   <string name="ssh_keygen_explanation_ecdsa"><b>ECDSA (NIST P-256)</b>\nSchnelle Authentifizierung, unterstützt von den meisten Servern, die noch Updates erhalten.</string>
-  <string name="ssh_keygen_explanation_ed25519"><b>Ed25519</b>\nSchnelle Authentifizierung, aber nur von moderneren Servern unterstützt</string>
   <string name="ssh_keygen_existing_title">SSH-Schlüssel</string>
   <string name="ssh_keygen_existing_message">Existierenden SSH-Schlüssel ersetzen? Möglicherweise verlieren Sie den Zugriff auf Ihren Server.</string>
   <string name="ssh_keygen_existing_replace">Ersetzen</string>
@@ -376,4 +374,5 @@
 
   <!-- Passphrase input -->
   <string name="cache_password_until_screen_off">Passphrase bis zum Abschalten des Bildschirms merken</string>
+  <string name="password_input">PGP-Passphrase</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -138,10 +138,8 @@
   <string name="ssh_keygen_require_authentication">Protéger avec les identifiants de verrouillage de l\'écran</string>
   <string name="ssh_keygen_label_rsa">RSA</string>
   <string name="ssh_keygen_label_ecdsa">ECDSA</string>
-  <string name="ssh_keygen_label_ed25519">Ed25519</string>
   <string name="ssh_keygen_explanation_rsa"><b>RSA (3072 bits)</b>\nAuthentification lente mais prise en charge par tous les serveurs.</string>
   <string name="ssh_keygen_explanation_ecdsa"><b>ECDSA (NIST P-256)</b>\nAuthentification rapide et prise en charge par la plupart des serveurs.</string>
-  <string name="ssh_keygen_explanation_ed25519"><b>Ed25519</b>\nAuthentification rapide mais prise en charge uniquement par des serveurs récents.</string>
   <string name="ssh_keygen_existing_title">Clé SSH</string>
   <string name="ssh_keygen_existing_message">Remplacer la clé SSH existante ? Vous risquez de perdre l\'accès à votre serveur.</string>
   <string name="ssh_keygen_existing_replace">Remplacer</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -146,10 +146,8 @@
   <string name="ssh_keygen_require_authentication">Protexe con credenciais de bloqueo de pantalla</string>
   <string name="ssh_keygen_label_rsa">RSA</string>
   <string name="ssh_keygen_label_ecdsa">ECDSA</string>
-  <string name="ssh_keygen_label_ed25519">Ed25519</string>
   <string name="ssh_keygen_explanation_rsa"><b>RSA (3072 bit)</b>\nSoportado por tódolos servidores, pero a autenticación é algo máis lenta.</string>
   <string name="ssh_keygen_explanation_ecdsa"><b>ECDSA (NIST P-256)</b>\nAutenticación rápida e soportado pola maioría dos servidores que estén actualizados.</string>
-  <string name="ssh_keygen_explanation_ed25519"><b>Ed25519</b>\nAutenticación rápida, pero só soportado polos servidores máis modernos.</string>
   <string name="ssh_keygen_existing_title">Chave SSH</string>
   <string name="ssh_keygen_existing_message">Substituír a chave SSH actual? Poderías perder o acceso ao servidor.</string>
   <string name="ssh_keygen_existing_replace">Substituír</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -133,10 +133,8 @@
   <string name="ssh_keygen_require_authentication">Proteggi con credenziali di blocco schermo</string>
   <string name="ssh_keygen_label_rsa">RSA</string>
   <string name="ssh_keygen_label_ecdsa">ECDSA</string>
-  <string name="ssh_keygen_label_ed25519">Ed25519</string>
   <string name="ssh_keygen_explanation_rsa"><b>RSA (3072 bit)</b>\nSupportato da tutti i server, ma l\'autenticazione è relativamente lenta.</string>
   <string name="ssh_keygen_explanation_ecdsa"><b>ECDSA (NIST P-256)</b>\nAutenticazione veloce e supportata da gran parte dei server che ricevono ancora aggiornamenti.</string>
-  <string name="ssh_keygen_explanation_ed25519"><b>Ed25519</b>\nAutenticazione veloce, ma supportata solo da server piuttosto moderni.</string>
   <string name="ssh_keygen_existing_title">Chiave SSH</string>
   <string name="ssh_keygen_existing_message">Sostituire la chiave SSH esistente? Potresti perdere l\'accesso al tuo server.</string>
   <string name="ssh_keygen_existing_replace">Sostituisci</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -144,10 +144,8 @@
   <string name="ssh_keygen_require_authentication">화면 잠금 자격 증명으로 보호</string>
   <string name="ssh_keygen_label_rsa">RSA</string>
   <string name="ssh_keygen_label_ecdsa">ECDSA</string>
-  <string name="ssh_keygen_label_ed25519">Ed25519</string>
   <string name="ssh_keygen_explanation_rsa"><b>RSA (3072 bit)</b>\n모든 서버에서 지원되지만, 인증 속도가 비교적 느립니다.</string>
   <string name="ssh_keygen_explanation_ecdsa"><b>ECDSA (NIST P-256)</b>\n빠른 인증이 가능하며, 아직 업데이트를 받고 있는 대부분의 서버에서 지원됩니다.</string>
-  <string name="ssh_keygen_explanation_ed25519"><b>Ed25519</b>\n빠른 인증이지만 다소 최신 서버에서만 지원됩니다.</string>
   <string name="ssh_keygen_existing_title">SSH 키</string>
   <string name="ssh_keygen_existing_message">기존 SSH 키를 교체하시나요? 서버에 액세스하지 못할 수 있습니다.</string>
   <string name="ssh_keygen_existing_replace">교체</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -143,10 +143,8 @@
   <string name="ssh_keygen_require_authentication">Chroń za pomocą blokady ekranu</string>
   <string name="ssh_keygen_label_rsa">RSA</string>
   <string name="ssh_keygen_label_ecdsa">ECDSA</string>
-  <string name="ssh_keygen_label_ed25519">Ed25519</string>
   <string name="ssh_keygen_explanation_rsa"><b>RSA (3072 bity)</b>\nObsługiwane przez wszystkie serwery, ale uwierzytelnianie jest stosunkowo powolne.</string>
   <string name="ssh_keygen_explanation_ecdsa"><b>ECDSA (NIST P-256)</b>\nSzybkie uwierzytelnianie i obsługiwane przez większość serwerów, które nadal otrzymują aktualizacje.</string>
-  <string name="ssh_keygen_explanation_ed25519"><b>Ed25519</b>\nSzybkie uwierzytelnienie, ale obsługiwane tylko przez dość nowoczesne serwery.</string>
   <string name="ssh_keygen_existing_title">Klucz SSH</string>
   <string name="ssh_keygen_existing_message">Zastąpić istniejący klucz SSH? Możesz stracić dostęp do swojego serwera.</string>
   <string name="ssh_keygen_existing_replace">Zastąp</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -145,10 +145,8 @@
   <string name="ssh_keygen_require_authentication">Proteja com credenciais de bloqueio de tela</string>
   <string name="ssh_keygen_label_rsa">RSA</string>
   <string name="ssh_keygen_label_ecdsa">ECDSA</string>
-  <string name="ssh_keygen_label_ed25519">Ed25519</string>
   <string name="ssh_keygen_explanation_rsa"><b>RSA (3072 bits)</b>\nSuportado por todos os servidores, mas a autenticação é relativamente lenta.</string>
   <string name="ssh_keygen_explanation_ecdsa"><b>ECDSA (NIST P-256)</b>\nAutenticação rápida e suportada pela maioria dos servidores que ainda estão recebendo atualizações.</string>
-  <string name="ssh_keygen_explanation_ed25519"><b>Ed25519</b>\nAutenticação rápida, mas apenas suportada por servidores bastante modernos.</string>
   <string name="ssh_keygen_existing_title">Chave SSH</string>
   <string name="ssh_keygen_existing_message">Substituir a chave SSH existente? Você pode perder o acesso ao seu servidor.</string>
   <string name="ssh_keygen_existing_replace">Substituir</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -142,10 +142,8 @@
   <string name="ssh_keygen_require_authentication">Использовать настройки блокировки экрана устройства</string>
   <string name="ssh_keygen_label_rsa">RSA</string>
   <string name="ssh_keygen_label_ecdsa">ECDSA</string>
-  <string name="ssh_keygen_label_ed25519">Ed25519</string>
   <string name="ssh_keygen_explanation_rsa"><b>RSA (3072 бит)</b>\nПоддерживается всеми серверами, но аутентификация является относительно медленной.</string>
   <string name="ssh_keygen_explanation_ecdsa"><b>ECDSA (NIST P-256)</b>\nБыстрая аутентификация, поддерживается большинством современных серверов.</string>
-  <string name="ssh_keygen_explanation_ed25519"><b>Ed25519</b>\nБыстрая аутентификация, но поддерживается только современными серверами.</string>
   <string name="ssh_keygen_existing_title">SSH ключ</string>
   <string name="ssh_keygen_existing_message">Заменить существующий SSH ключ? Вы можете потерять доступ к вашему серверу.</string>
   <string name="ssh_keygen_existing_replace">Заменить</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -146,13 +146,10 @@
   <string name="ssh_keygen_require_authentication">使用屏幕锁定进行保护</string>
   <string name="ssh_keygen_label_rsa">RSA</string>
   <string name="ssh_keygen_label_ecdsa">ECDSA</string>
-  <string name="ssh_keygen_label_ed25519">Ed25519</string>
   <string name="ssh_keygen_explanation_rsa"><b>RSA (3072 bit)</b>\"
 所有服务器都支持,但身份验证相对较慢\"</string>
   <string name="ssh_keygen_explanation_ecdsa"><b>ECDSA (NIST P-256)</b>\"
 快速身份验证,并受仍在接收更新的大多数服务器的支持\"</string>
-  <string name="ssh_keygen_explanation_ed25519"><b>Ed25519</b>\"
-快速身份验证,但仅受相当现代的服务器支持\"</string>
   <string name="ssh_keygen_existing_title">SSH密钥</string>
   <string name="ssh_keygen_existing_message">替换现有的SSH密钥?您可能会失去对服务器的访问权限</string>
   <string name="ssh_keygen_existing_replace">替换</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,10 +168,8 @@
   <string name="ssh_keygen_require_authentication">Protect with screen lock credential</string>
   <string name="ssh_keygen_label_rsa">RSA</string>
   <string name="ssh_keygen_label_ecdsa">ECDSA</string>
-  <string name="ssh_keygen_label_ed25519">Ed25519</string>
   <string name="ssh_keygen_explanation_rsa"><b>RSA (3072 bit)</b>\nSupported by all servers, but authentication is comparatively slow.</string>
   <string name="ssh_keygen_explanation_ecdsa"><b>ECDSA (NIST P-256)</b>\nFast authentication and supported by most servers that are still receiving updates.</string>
-  <string name="ssh_keygen_explanation_ed25519"><b>Ed25519</b>\nFast authentication, but only supported by rather modern servers.</string>
   <string name="ssh_keygen_existing_title">SSH key</string>
   <string name="ssh_keygen_existing_message">Replace existing SSH key? You might lose access to your server.</string>
   <string name="ssh_keygen_existing_replace">Replace</string>
@@ -376,5 +374,6 @@
   <string name="aead_detect_message">%1$s, see https://passwordstore.app/fix-aead for more information</string>
 
   <!-- Passphrase input -->
-  <string name="cache_password_until_screen_off">Keep password until screen-off</string>
+  <string name="cache_password_until_screen_off">Keep passphrase until screen-off</string>
+  <string name="password_input">PGP Passphrase</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,7 +75,6 @@ thirdparty-bouncycastle-bcutil = { module = "org.bouncycastle:bcutil-jdk18on", v
 # noinspection GradleDependency
 thirdparty-commons_codec = "commons-codec:commons-codec:1.14"
 thirdparty-compose-lints = "com.slack.lint.compose:compose-lint-checks:1.4.2"
-thirdparty-eddsa = "net.i2p.crypto:eddsa:0.3.0"
 thirdparty-fastscroll = "me.zhanghai.android.fastscroll:library:1.3.0"
 thirdparty-flowbinding-android = { module = "io.github.reactivecircus.flowbinding:flowbinding-android", version.ref = "flowbinding" }
 # JGit upgrades also raise its minimum Java runtime requirements that we cannot satisfy on Android


### PR DESCRIPTION
Fixes #34.

Removes APS' dependency on the deprecated `androidx.security.crypto` library with its `EncryptedSharedPreferences` and `EncryptedFile` classes.