### PR TITLE
Start from empty cloned repo

### DIFF
--- a/crypto/pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPKeyManager.kt
+++ b/crypto/pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPKeyManager.kt
@@ -138,7 +138,7 @@ constructor(filesDir: String, private val dispatcher: CoroutineDispatcher) :
       }
     }
 
-  /** @see KeyManager.getKeyById */
+  /** @see KeyManager.getKeyId */
   override suspend fun getKeyId(key: PGPKey): PGPIdentifier? = tryGetId(key)
 
   /** Checks if [keyDir] exists and attempts to create it if not. */


### PR DESCRIPTION
- It is now possible to start from an empty cloned repo (empty, but with an initial commit, e.g. a dummy file added and removed on the Git server). The PGP key selection dialog will be presented to the user in that case.
- `.gpg-id` is now initialised with the numeric key ID (16 Hex figures)