### PR TITLE
password edit dialog auto dismiss on timeout

### DIFF
--- a/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
@@ -36,6 +36,9 @@ import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.File
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -198,6 +201,23 @@ open class BasePGPActivity : AppCompatActivity() {
       parent.findTillRoot(fileName, rootPath)
     } else {
       null
+    }
+  }
+
+  /**
+   * Automatically finishes the activity after [PreferenceKeys.GENERAL_SHOW_TIME] seconds decryption
+   * succeeded to prevent information leaks from stale activities. Cancel with .cancel() on returned
+   * object.
+   */
+  protected fun startAutoDismissTimer(): Job {
+    return lifecycleScope.launch {
+      val timeout =
+        settings.getString(PreferenceKeys.GENERAL_SHOW_TIME)?.toIntOrNull()
+          ?: Constants.DEFAULT_DECRYPTION_TIMEOUT
+      if (timeout != 0) {
+        delay(timeout.seconds)
+        finish()
+      }
     }
   }
 

--- a/app/src/main/java/app/passwordstore/ui/crypto/DecryptActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/DecryptActivity.kt
@@ -24,7 +24,6 @@ import app.passwordstore.util.extensions.getString
 import app.passwordstore.util.extensions.unsafeLazy
 import app.passwordstore.util.extensions.viewBinding
 import app.passwordstore.util.features.Features
-import app.passwordstore.util.settings.Constants
 import app.passwordstore.util.settings.PreferenceKeys
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.runCatching
@@ -32,8 +31,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.io.ByteArrayOutputStream
 import java.io.File
 import javax.inject.Inject
-import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -90,22 +87,6 @@ class DecryptActivity : BasePGPActivity() {
       else -> return super.onOptionsItemSelected(item)
     }
     return true
-  }
-
-  /**
-   * Automatically finishes the activity after [PreferenceKeys.GENERAL_SHOW_TIME] seconds decryption
-   * succeeded to prevent information leaks from stale activities.
-   */
-  private fun startAutoDismissTimer() {
-    lifecycleScope.launch {
-      val timeout =
-        settings.getString(PreferenceKeys.GENERAL_SHOW_TIME)?.toIntOrNull()
-          ?: Constants.DEFAULT_DECRYPTION_TIMEOUT
-      if (timeout != 0) {
-        delay(timeout.seconds)
-        finish()
-      }
-    }
   }
 
   /**

--- a/app/src/main/java/app/passwordstore/ui/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/PasswordCreationActivity.kt
@@ -65,6 +65,7 @@ import kotlin.io.path.nameWithoutExtension
 import kotlin.io.path.pathString
 import kotlin.io.path.relativeTo
 import kotlin.io.path.writeBytes
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import logcat.LogPriority.ERROR
@@ -87,6 +88,8 @@ class PasswordCreationActivity : BasePGPActivity() {
   private val editing by unsafeLazy { intent.getBooleanExtra(EXTRA_EDITING, false) }
   private var oldCategory: String? = null
   private var copy: Boolean = false
+
+  private var timer: Job? = null
 
   private val otpImportAction =
     registerForActivityResult(StartActivityForResult()) { result ->
@@ -303,6 +306,8 @@ class PasswordCreationActivity : BasePGPActivity() {
 
   private fun updateViewState() =
     with(binding) {
+      timer?.cancel()
+      timer = startAutoDismissTimer()
       encryptUsername.apply {
         if (visibility != View.VISIBLE) return@apply
         val hasUsernameInFileName = filename.text.toString().isNotBlank()


### PR DESCRIPTION
An open password edit dialog remains open during extended user inactivity and becomes visible again after waking up a sleeping device. This PR re-uses the existing `startAutoDismissTimer()` function to close `PasswordCreationActivity` after a configurable timeout (same as password copy timeout). The timer is refreshed whenever the activity is updated, e. g. upon user input.