### PR TITLE
fix app crash on missing or empty .gpg-id

### DIFF
--- a/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
@@ -157,14 +157,12 @@ open class BasePGPActivity : AppCompatActivity() {
    */
   fun getPGPIdentifiers(subDir: String): List<PGPIdentifier>? {
     val repoRoot = PasswordRepository.getRepositoryDirectory()
-    val gpgIdentifierFile =
-      File(repoRoot, subDir).findTillRoot(".gpg-id", repoRoot)
-        ?: File(repoRoot, ".gpg-id").apply { createNewFile() }
+    val gpgIdentifierFile = File(repoRoot, subDir).findTillRoot(".gpg-id", repoRoot)
     val gpgIdentifiers =
       gpgIdentifierFile
-        .readLines()
-        .filter { it.isNotBlank() }
-        .map { line ->
+        ?.readLines()
+        ?.filter { it.isNotBlank() }
+        ?.map { line ->
           PGPIdentifier.fromString(line)
             ?: run {
               // The line being empty means this is most likely an empty `.gpg-id`
@@ -181,9 +179,14 @@ open class BasePGPActivity : AppCompatActivity() {
               return null
             }
         }
-        .filterIsInstance<PGPIdentifier>()
-    if (gpgIdentifiers.isEmpty()) {
-      error("Failed to parse identifiers from .gpg-id: ${gpgIdentifierFile.readText()}")
+        ?.filterIsInstance<PGPIdentifier>()
+    if (gpgIdentifiers.isNullOrEmpty()) {
+      if (gpgIdentifiers == null) {
+        snackbar(message = resources.getString(R.string.missing_gpg_id))
+      } else {
+        snackbar(message = resources.getString(R.string.empty_gpg_id))
+      }
+      return null
     }
     return gpgIdentifiers
   }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -299,6 +299,8 @@
   <string name="otp_import_failure_no_selection">Keine Bilddatei ausgewählt</string>
   <string name="exporting_passwords">Passwörter werden exportiert.</string>
   <string name="invalid_gpg_id">.gpg-id wurde gefunden, enthält jedoch ungültige Schlüssel-ID, Fingerabdruck oder Benutzer-ID.</string>
+  <string name="empty_gpg_id">.gpg-id wurde gefunden, ist jedoch leer.</string>
+  <string name="missing_gpg_id">.gpg-id wurde nicht gefunden.</string>
   <string name="short_gpg_id">.gpg-id wurde gefunden, enthält jedoch eine kurze Hex-ID, die nicht unterstützt wird.</string>
   <string name="invalid_filename_text">Dateiname darf kein \'/\' enthalten; Verzeichnis oben setzen</string>
   <string name="directory_hint">Ordner</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -300,6 +300,8 @@
   <string name="otp_import_failure_no_selection">No image file was selected</string>
   <string name="exporting_passwords">Exporting passwords…</string>
   <string name="invalid_gpg_id">Found .gpg-id, but it contains an invalid key ID, fingerprint or user ID</string>
+  <string name="empty_gpg_id">Found .gpg-id, but it is empty.</string>
+  <string name="missing_gpg_id">No .gpg-id could be found.</string>
   <string name="short_gpg_id">Found .gpg-id, but it contains a short hex ID, which is not supported</string>
   <string name="invalid_filename_text">File name must not contain \'/\', set directory above</string>
   <string name="directory_hint">Directory</string>


### PR DESCRIPTION
This PR fixes application crashes that occur when `.gpg-id` is missing or empty. Related issue in the original repo: https://github.com/android-password-store/Android-Password-Store/issues/3227.