### PR TITLE
fix app crash due to missing/invalid .gpg-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 -   Auto-dismiss an abandoned password edit dialog after configurable timeout (password copy timeout is used) to prevent information leakage
 -   Initialising an empty cloned non-pass repo is now possible. The repo to be cloned should however already have at least one commit, e. g. an added and removed dummy file
+-   Fix app crashes due to `.gpg-id` with invalid or unknown key/user ID. Prompt for re-selecting/re-importing a PGP secret key file.
 
 ### Changed
 -   **BREAKING**: The option for generating the SSH key pair in the Ed25519 format was removed from APS. It relied on the now deprecated `androidx.security:security-crypto` library to store the private key as an encrypted file in the application's hidden directory. Use one of Android KeyStore native RSA or ECDSA key format options when generating the SSH key pair. Alternatively, an externally generated SSH private key can be imported into the app. Imported SSH private keys can be in any format, including Ed25519, but they should be secured with a passphrase

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,6 +44,11 @@
       android:exported="false" />
 
     <activity
+      android:name=".ui.onboarding.activity.KeySelectionActivity"
+      android:configChanges="orientation|screenSize"
+      android:exported="false" />
+
+    <activity
       android:name=".ui.proxy.ProxySelectorActivity"
       android:exported="false"
       android:label="@string/activity_proxy_label"

--- a/app/src/main/java/app/passwordstore/Application.kt
+++ b/app/src/main/java/app/passwordstore/Application.kt
@@ -12,6 +12,7 @@ import android.content.SharedPreferences
 import android.os.Build
 import android.os.StrictMode
 import androidx.appcompat.app.AppCompatDelegate.*
+import app.passwordstore.data.repo.PasswordRepository
 import app.passwordstore.injection.context.FilesDirPath
 import app.passwordstore.injection.prefs.SettingsPreferences
 import app.passwordstore.ui.crypto.BasePGPActivity.Companion.cachedPassphrase
@@ -25,6 +26,7 @@ import app.passwordstore.util.settings.PreferenceKeys
 import app.passwordstore.util.settings.runMigrations
 import com.google.android.material.color.DynamicColors
 import dagger.hilt.android.HiltAndroidApp
+import java.io.File
 import java.util.concurrent.Executors
 import javax.inject.Inject
 import logcat.AndroidLogcatLogger
@@ -61,6 +63,8 @@ class Application : android.app.Application(), SharedPreferences.OnSharedPrefere
     proxyUtils.setDefaultProxy()
     DynamicColors.applyToActivitiesIfAvailable(this)
     setupScreenOffHandler()
+    PasswordRepository.gpgidIsValid =
+      File(PasswordRepository.getRepositoryDirectory(), ".gpg-id").isFile()
   }
 
   private fun setupScreenOffHandler() {

--- a/app/src/main/java/app/passwordstore/data/crypto/CryptoRepository.kt
+++ b/app/src/main/java/app/passwordstore/data/crypto/CryptoRepository.kt
@@ -37,6 +37,10 @@ constructor(
     }
   }
 
+  suspend fun hasKey(id: PGPIdentifier): Boolean {
+    return withContext(dispatcherProvider.io()) { pgpKeyManager.getKeyById(id).isOk }
+  }
+
   suspend fun isPasswordProtected(identifiers: List<PGPIdentifier>): Boolean {
     val keys = identifiers.map { pgpKeyManager.getKeyById(it) }.filterValues()
     return pgpCryptoHandler.isPassphraseProtected(keys)

--- a/app/src/main/java/app/passwordstore/data/repo/PasswordRepository.kt
+++ b/app/src/main/java/app/passwordstore/data/repo/PasswordRepository.kt
@@ -33,6 +33,8 @@ object PasswordRepository {
   val isInitialized: Boolean
     get() = repository != null
 
+  var gpgidIsValid: Boolean = false
+
   fun isGitRepo(): Boolean {
     return repository?.objectDatabase?.exists() ?: false
   }
@@ -122,7 +124,6 @@ object PasswordRepository {
         putBoolean(PreferenceKeys.REPOSITORY_INITIALIZED, false)
       } else {
         putBoolean(PreferenceKeys.REPOSITORY_INITIALIZED, true)
-        putBoolean(PreferenceKeys.GPG_ID_INITIALIZED, File(dir, ".gpg-id").isFile())
       }
     }
     // Create the repository static variable in PasswordRepository

--- a/app/src/main/java/app/passwordstore/data/repo/PasswordRepository.kt
+++ b/app/src/main/java/app/passwordstore/data/repo/PasswordRepository.kt
@@ -122,6 +122,7 @@ object PasswordRepository {
         putBoolean(PreferenceKeys.REPOSITORY_INITIALIZED, false)
       } else {
         putBoolean(PreferenceKeys.REPOSITORY_INITIALIZED, true)
+        putBoolean(PreferenceKeys.GPG_ID_INITIALIZED, File(dir, ".gpg-id").isFile())
       }
     }
     // Create the repository static variable in PasswordRepository

--- a/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
@@ -16,6 +16,7 @@ import androidx.activity.result.contract.ActivityResultContracts.StartActivityFo
 import androidx.annotation.CallSuper
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.edit
 import androidx.lifecycle.lifecycleScope
 import app.passwordstore.R
 import app.passwordstore.crypto.PGPIdentifier
@@ -186,6 +187,7 @@ open class BasePGPActivity : AppCompatActivity() {
       } else {
         snackbar(message = resources.getString(R.string.empty_gpg_id))
       }
+      settings.edit { putBoolean(PreferenceKeys.GPG_ID_INITIALIZED, false) }
       return null
     }
     return gpgIdentifiers

--- a/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
@@ -16,7 +16,6 @@ import androidx.activity.result.contract.ActivityResultContracts.StartActivityFo
 import androidx.annotation.CallSuper
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.edit
 import androidx.lifecycle.lifecycleScope
 import app.passwordstore.R
 import app.passwordstore.crypto.PGPIdentifier
@@ -41,6 +40,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
 @Suppress("Registered")
@@ -157,37 +157,44 @@ open class BasePGPActivity : AppCompatActivity() {
    * the problem.
    */
   fun getPGPIdentifiers(subDir: String): List<PGPIdentifier>? {
+    var shortIdCount = 0
+    var invalidIdCount = 0
     val repoRoot = PasswordRepository.getRepositoryDirectory()
     val gpgIdentifierFile = File(repoRoot, subDir).findTillRoot(".gpg-id", repoRoot)
+    if (gpgIdentifierFile == null) {
+      snackbar(message = resources.getString(R.string.missing_gpg_id))
+      PasswordRepository.gpgidIsValid = false
+      return null
+    }
     val gpgIdentifiers =
       gpgIdentifierFile
-        ?.readLines()
-        ?.filter { it.isNotBlank() }
-        ?.map { line ->
-          PGPIdentifier.fromString(line)
-            ?: run {
-              // The line being empty means this is most likely an empty `.gpg-id`
-              // file we created. Skip the validation so we can make the user add a
-              // real ID.
-              if (line.isEmpty()) return@run
-              // Apparently `gpg-id` being the first line is also acceptable?
-              if (line == "gpg-id") return@run
-              if (line.removePrefix("0x").matches("[a-fA-F0-9]{8}".toRegex())) {
-                snackbar(message = resources.getString(R.string.short_gpg_id))
-              } else {
-                snackbar(message = resources.getString(R.string.invalid_gpg_id))
-              }
-              return null
-            }
+        .readLines()
+        .filter { it.isNotBlank() }
+        .map { line ->
+          if (line == "gpg-id") {
+            null
+          } else if (line.removePrefix("0x").matches("[a-fA-F0-9]{8}".toRegex())) {
+            // Short key IDs are not accepted
+            shortIdCount++
+            null
+          } else {
+            val id = PGPIdentifier.fromString(line)
+            if (id == null || !runBlocking { repository.hasKey(id) }) {
+              invalidIdCount++
+              null
+            } else id
+          }
         }
-        ?.filterIsInstance<PGPIdentifier>()
+        .filterIsInstance<PGPIdentifier>()
     if (gpgIdentifiers.isNullOrEmpty()) {
-      if (gpgIdentifiers == null) {
-        snackbar(message = resources.getString(R.string.missing_gpg_id))
-      } else {
+      if (shortIdCount == 0 && invalidIdCount == 0) {
         snackbar(message = resources.getString(R.string.empty_gpg_id))
+      } else if (shortIdCount > 0 && invalidIdCount == 0) {
+        snackbar(message = resources.getString(R.string.short_gpg_id))
+      } else if (shortIdCount == 0 && invalidIdCount > 0) {
+        snackbar(message = resources.getString(R.string.invalid_gpg_id))
       }
-      settings.edit { putBoolean(PreferenceKeys.GPG_ID_INITIALIZED, false) }
+      PasswordRepository.gpgidIsValid = false
       return null
     }
     return gpgIdentifiers

--- a/app/src/main/java/app/passwordstore/ui/onboarding/activity/KeySelectionActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/onboarding/activity/KeySelectionActivity.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2014-2024 The Android Password Store Authors. All Rights Reserved.
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package app.passwordstore.ui.onboarding.activity
+
+import android.os.Bundle
+import androidx.activity.addCallback
+import androidx.appcompat.app.AppCompatActivity
+import app.passwordstore.R
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class KeySelectionActivity : AppCompatActivity(R.layout.activity_keyselection) {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    supportActionBar?.hide()
+    val callback = onBackPressedDispatcher.addCallback(enabled = false) { finishAffinity() }
+    supportFragmentManager.addOnBackStackChangedListener {
+      if (supportFragmentManager.backStackEntryCount == 0) {
+        callback.isEnabled = true
+      }
+    }
+  }
+}

--- a/app/src/main/java/app/passwordstore/ui/onboarding/fragments/KeySelectionFragment.kt
+++ b/app/src/main/java/app/passwordstore/ui/onboarding/fragments/KeySelectionFragment.kt
@@ -57,7 +57,7 @@ class KeySelectionFragment : Fragment(R.layout.fragment_key_selection) {
             gpgIdentifierFile.writeText(keyId.toString())
           }
           settings.edit { putBoolean(PreferenceKeys.REPOSITORY_INITIALIZED, true) }
-          settings.edit { putBoolean(PreferenceKeys.GPG_ID_INITIALIZED, true) }
+          PasswordRepository.gpgidIsValid = true
           requireActivity()
             .commitChange(getString(R.string.git_commit_gpg_id, getString(R.string.app_name)))
           finish()

--- a/app/src/main/java/app/passwordstore/ui/onboarding/fragments/KeySelectionFragment.kt
+++ b/app/src/main/java/app/passwordstore/ui/onboarding/fragments/KeySelectionFragment.kt
@@ -57,6 +57,7 @@ class KeySelectionFragment : Fragment(R.layout.fragment_key_selection) {
             gpgIdentifierFile.writeText(keyId.toString())
           }
           settings.edit { putBoolean(PreferenceKeys.REPOSITORY_INITIALIZED, true) }
+          settings.edit { putBoolean(PreferenceKeys.GPG_ID_INITIALIZED, true) }
           requireActivity()
             .commitChange(getString(R.string.git_commit_gpg_id, getString(R.string.app_name)))
           finish()

--- a/app/src/main/java/app/passwordstore/ui/passwords/PasswordStore.kt
+++ b/app/src/main/java/app/passwordstore/ui/passwords/PasswordStore.kt
@@ -71,6 +71,7 @@ class PasswordStore : BaseGitActivity() {
   @Inject lateinit var shortcutHandler: ShortcutHandler
   private lateinit var searchItem: MenuItem
   private val settings by lazy { sharedPrefs }
+  //  @SettingsPreferences @Inject lateinit var settings: SharedPreferences
 
   private val model: SearchableRepositoryViewModel by viewModels()
 
@@ -351,7 +352,7 @@ class PasswordStore : BaseGitActivity() {
 
   private fun checkLocalRepository(localDir: File?) {
     if (localDir != null && settings.getBoolean(PreferenceKeys.REPOSITORY_INITIALIZED, false)) {
-      if (!settings.getBoolean(PreferenceKeys.GPG_ID_INITIALIZED, false)) {
+      if (!PasswordRepository.gpgidIsValid) {
         launchActivity(KeySelectionActivity::class.java)
       } else {
         // do not push the fragment if we already have it

--- a/app/src/main/java/app/passwordstore/ui/passwords/PasswordStore.kt
+++ b/app/src/main/java/app/passwordstore/ui/passwords/PasswordStore.kt
@@ -32,6 +32,7 @@ import app.passwordstore.ui.crypto.PasswordCreationActivity
 import app.passwordstore.ui.dialogs.FolderCreationDialogFragment
 import app.passwordstore.ui.folderselect.SelectFolderActivity
 import app.passwordstore.ui.git.base.BaseGitActivity
+import app.passwordstore.ui.onboarding.activity.KeySelectionActivity
 import app.passwordstore.ui.onboarding.activity.OnboardingActivity
 import app.passwordstore.ui.settings.SettingsActivity
 import app.passwordstore.util.autofill.AutofillMatcher
@@ -350,26 +351,30 @@ class PasswordStore : BaseGitActivity() {
 
   private fun checkLocalRepository(localDir: File?) {
     if (localDir != null && settings.getBoolean(PreferenceKeys.REPOSITORY_INITIALIZED, false)) {
-      // do not push the fragment if we already have it
-      if (
-        getPasswordFragment() == null || settings.getBoolean(PreferenceKeys.REPO_CHANGED, false)
-      ) {
-        settings.edit { putBoolean(PreferenceKeys.REPO_CHANGED, false) }
-        val args = Bundle()
-        args.putString(REQUEST_ARG_PATH, PasswordRepository.getRepositoryDirectory().absolutePath)
+      if (!settings.getBoolean(PreferenceKeys.GPG_ID_INITIALIZED, false)) {
+        launchActivity(KeySelectionActivity::class.java)
+      } else {
+        // do not push the fragment if we already have it
+        if (
+          getPasswordFragment() == null || settings.getBoolean(PreferenceKeys.REPO_CHANGED, false)
+        ) {
+          settings.edit { putBoolean(PreferenceKeys.REPO_CHANGED, false) }
+          val args = Bundle()
+          args.putString(REQUEST_ARG_PATH, PasswordRepository.getRepositoryDirectory().absolutePath)
 
-        // if the activity was started from the autofill settings, the
-        // intent is to match a clicked pwd with app. pass this to fragment
-        if (intent.getBooleanExtra("matchWith", false)) {
-          args.putBoolean("matchWith", true)
-        }
-        supportActionBar?.apply {
-          show()
-          setDisplayHomeAsUpEnabled(false)
-        }
-        supportFragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
-        supportFragmentManager.commit {
-          replace(R.id.main_layout, PasswordFragment.newInstance(args), PASSWORD_FRAGMENT_TAG)
+          // if the activity was started from the autofill settings, the
+          // intent is to match a clicked pwd with app. pass this to fragment
+          if (intent.getBooleanExtra("matchWith", false)) {
+            args.putBoolean("matchWith", true)
+          }
+          supportActionBar?.apply {
+            show()
+            setDisplayHomeAsUpEnabled(false)
+          }
+          supportFragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+          supportFragmentManager.commit {
+            replace(R.id.main_layout, PasswordFragment.newInstance(args), PASSWORD_FRAGMENT_TAG)
+          }
         }
       }
     } else {

--- a/app/src/main/java/app/passwordstore/util/settings/PreferenceKeys.kt
+++ b/app/src/main/java/app/passwordstore/util/settings/PreferenceKeys.kt
@@ -63,7 +63,6 @@ object PreferenceKeys {
   const val DIRECTORY_STRUCTURE = "oreo_autofill_directory_structure"
   const val PREF_KEY_PWGEN_TYPE = "pref_key_pwgen_type"
   const val REPOSITORY_INITIALIZED = "repository_initialized"
-  const val GPG_ID_INITIALIZED = "gpg_id_initialized"
   const val REPO_CHANGED = "repo_changed"
   const val SEARCH_ON_START = "search_on_start"
 

--- a/app/src/main/java/app/passwordstore/util/settings/PreferenceKeys.kt
+++ b/app/src/main/java/app/passwordstore/util/settings/PreferenceKeys.kt
@@ -63,6 +63,7 @@ object PreferenceKeys {
   const val DIRECTORY_STRUCTURE = "oreo_autofill_directory_structure"
   const val PREF_KEY_PWGEN_TYPE = "pref_key_pwgen_type"
   const val REPOSITORY_INITIALIZED = "repository_initialized"
+  const val GPG_ID_INITIALIZED = "gpg_id_initialized"
   const val REPO_CHANGED = "repo_changed"
   const val SEARCH_ON_START = "search_on_start"
 

--- a/app/src/main/res/layout/activity_keyselection.xml
+++ b/app/src/main/res/layout/activity_keyselection.xml
@@ -1,0 +1,11 @@
+<!--
+  ~ Copyright © 2014-2024 The Android Password Store Authors. All Rights Reserved.
+  ~ SPDX-License-Identifier: GPL-3.0-only
+  -->
+
+<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
+  android:id="@+id/fragment_key_reselect"
+  android:name="app.passwordstore.ui.onboarding.fragments.KeySelectionFragment"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:tag="keyselection_fragment" />

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -298,7 +298,7 @@
   <string name="otp_import_failure_generic">Import der TOTP-Konfiguration fehlgeschlagen</string>
   <string name="otp_import_failure_no_selection">Keine Bilddatei ausgewählt</string>
   <string name="exporting_passwords">Passwörter werden exportiert.</string>
-  <string name="invalid_gpg_id">.gpg-id wurde gefunden, enthält jedoch ungültige Schlüssel-ID, Fingerabdruck oder Benutzer-ID.</string>
+  <string name="invalid_gpg_id">.gpg-id wurde gefunden, enthält jedoch ungültige oder unbekannte Schlüssel-ID.</string>
   <string name="empty_gpg_id">.gpg-id wurde gefunden, ist jedoch leer.</string>
   <string name="missing_gpg_id">.gpg-id wurde nicht gefunden.</string>
   <string name="short_gpg_id">.gpg-id wurde gefunden, enthält jedoch eine kurze Hex-ID, die nicht unterstützt wird.</string>
@@ -319,7 +319,7 @@
   <string name="git_break_out_of_detached_success">Es gab einen Konflikt während des Rebase-Prozesses. Ihr lokaler Branch %1$s wurde auf einen anderen Branch namens %2$s gepusht.\nNutzen Sie diesen Branch, um den Konflikt auf dem Server zu beheben</string>
   <string name="git_break_out_of_detached_unneeded">Das Repository befindet sich nicht im Rebase-Prozess; es ist nicht nötig, den Zustand auf einen weiteren Branch zu pushen.</string>
 
-  <!-- GPG key selection in folder creation -->
+  <!-- PGP key selection in folder creation -->
   <string name="gpg_key_select_mandatory">Um fortzufahren, muss ein PGP-Schlüssel ausgewählt werden.</string>
   <string name="folder_creation_err_file_exists">Dateiname bereits vergeben</string>
   <string name="folder_creation_err_folder_exists">Ein Ordner mit diesem Namen existiert bereits.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -261,7 +261,7 @@
   <string name="exporting_passwords">Exportation des mots de passe…</string>
   <string name="invalid_filename_text">Le nom du fichier ne doit pas contenir \'/\', définir le répertoire parent</string>
   <string name="directory_hint">Dossier</string>
-  <string name="new_folder_set_gpg_key">Définir la clé GPG pour le dossier</string>
+  <string name="new_folder_set_gpg_key">Définir la clé PGP pour le dossier</string>
   <!-- GitException messages -->
   <string name="git_unknown_error">Erreur inconnue</string>
   <string name="git_pull_rebase_fail_error">Tirer a échoué, vous êtes dans un \'head\' détaché. En utilisant \"settings &gt; git utils\", enregistrez vos modifications sur le dépôt distant dans une nouvelle branche et résolvez le conflit sur votre ordinateur.</string>
@@ -273,7 +273,7 @@
   <string name="git_operation_running">Opération git en cours…</string>
   <string name="git_break_out_of_detached_success">Il y a eu un conflit lors de la tentative de rebase. Votre branche locale %1$s a été poussée vers une autre branche nommée %2$s\n Utilisez cette branche pour résoudre les conflits sur votre ordinateur</string>
   <string name="git_break_out_of_detached_unneeded">Le dépôt n\'est pas rebasé, pas besoin de pousser vers une autre branche</string>
-  <!-- GPG key selection in folder creation -->
+  <!-- PGP key selection in folder creation -->
   <string name="folder_creation_err_file_exists">Un fichier portant ce nom existe déjà</string>
   <string name="folder_creation_err_folder_exists">Un dossier portant ce nom existe déjà</string>
   <!-- Onboarding flow -->
@@ -282,8 +282,8 @@
   <string name="select_repo_type_text">Sélectionnez si vous voulez créer un dépôt local ou cloner un dépôt distant.</string>
   <string name="clone_remote_repo">Cloner le dépôt distant</string>
   <string name="create_local_repo">Créer un dépôt local</string>
-  <string name="select_gpg_key_title">Sélectionnez\nla clé GPG</string>
-  <string name="select_gpg_key_message">Sélectionnez une clé GPG pour initialiser votre magasin</string>
+  <string name="select_gpg_key_title">Sélectionnez\nla clé PGP</string>
+  <string name="select_gpg_key_message">Sélectionnez une clé PGP pour initialiser votre magasin</string>
   <string name="gpg_key_select">Sélectionner la clé</string>
   <!-- SSH port validation -->
   <string name="ssh_scheme_needed_title">URL potentiellement incorrecte</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -36,7 +36,7 @@
   <string name="git_commit_remove_text">Eliminar %1$s da almacenaxe.</string>
   <string name="git_commit_move_text">Mudar nome %1$s a %2$s.</string>
   <string name="git_commit_move_multiple_text">Mover varios contrasinais a %1$s.</string>
-  <string name="git_commit_gpg_id">Iniciar cos IDs GPG en %1$s.</string>
+  <string name="git_commit_gpg_id">Iniciar cos IDs PGP en %1$s.</string>
   <!-- PGPHandler -->
   <string name="clipboard_copied_text">Copiado ao portapapeis</string>
   <string name="file_toast_text">Debes proporcionar un nome de ficheiro</string>
@@ -269,11 +269,11 @@ a app desde unha fonte de confianza, como a Play Store, Amazon Appstore, F-Droid
   <string name="otp_import_failure_generic">Fallou a importación da configuración TOTP</string>
   <string name="otp_import_failure_no_selection">Non se seleccionou ningún ficheiro de imaxe</string>
   <string name="exporting_passwords">Exportando contrasinais…</string>
-  <string name="invalid_gpg_id">Atopouse .gpg-id, pero contén un ID de chave, impresión dixital ou ID de usuaria non válidos</string>
+  <string name="invalid_gpg_id">Atopouse .gpg-id, pero contén un ID de chave non válido ou descoñecido.</string>
   <string name="short_gpg_id">Atopouse .gpg-id, pero contén un ID hex curto, ao que non damos soporte</string>
   <string name="invalid_filename_text">O nome do ficheiro non pode conter \'/\', establece un directorio superior</string>
   <string name="directory_hint">Directorio</string>
-  <string name="new_folder_set_gpg_key">Establece chave GPG para o directorio</string>
+  <string name="new_folder_set_gpg_key">Establece chave PGP para o directorio</string>
   <!-- GitException messages -->
   <string name="git_unknown_error">Fallo descoñecido</string>
   <string name="git_pull_rebase_fail_error">Fallou a acción pull, estás nun head diferente. Utiliza \"axustes &gt; utilidades git\", garda os cambios no remoto nunha nova rama e resolve o conflicto nun ordenador.</string>
@@ -285,8 +285,8 @@ a app desde unha fonte de confianza, como a Play Store, Amazon Appstore, F-Droid
   <string name="git_operation_running">Realizando operación git…</string>
   <string name="git_break_out_of_detached_success">Hai un conflito ó realizar rebase. A túa póla local %1$s fixo push a outra póla chamada %2$s\nUsa esta póla para resolver o conflito na túa computadora</string>
   <string name="git_break_out_of_detached_unneeded">O repositorio non cambiou de base, non é preciso cambiar a outra póla</string>
-  <!-- GPG key selection in folder creation -->
-  <string name="gpg_key_select_mandatory">Hai que elexir unha chave GPG para continuar</string>
+  <!-- PGP key selection in folder creation -->
+  <string name="gpg_key_select_mandatory">Hai que elexir unha chave PGP para continuar</string>
   <string name="folder_creation_err_file_exists">Xa existe un ficheiro con ese nome</string>
   <string name="folder_creation_err_folder_exists">Xa existe un cartafol con ese nome</string>
   <!-- Onboarding flow -->
@@ -295,8 +295,8 @@ a app desde unha fonte de confianza, como a Play Store, Amazon Appstore, F-Droid
   <string name="select_repo_type_text">Escolle se queres crear un repositorio local ou clonar un remoto.</string>
   <string name="clone_remote_repo">Clonar repositorio remoto</string>
   <string name="create_local_repo">Crear repositorio local</string>
-  <string name="select_gpg_key_title">Elixe\nChave\nGPG</string>
-  <string name="select_gpg_key_message">Elixe a chave GPG coa que queres iniciar a almacenaxe</string>
+  <string name="select_gpg_key_title">Elixe\nChave\nPGP</string>
+  <string name="select_gpg_key_message">Elixe a chave PGP coa que queres iniciar a almacenaxe</string>
   <string name="gpg_key_select">Elixe chave</string>
   <!-- SSH port validation -->
   <string name="ssh_scheme_needed_title">URL potencialmente incorrecto</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -256,7 +256,7 @@
   <string name="exporting_passwords">Esportando le password…</string>
   <string name="invalid_filename_text">Il nome del file non deve contenere \'/0, imposta la directory sopra</string>
   <string name="directory_hint">Directory</string>
-  <string name="new_folder_set_gpg_key">Imposta la chiave GPG per la directory</string>
+  <string name="new_folder_set_gpg_key">Imposta la chiave PGP per la directory</string>
   <!-- GitException messages -->
   <string name="git_unknown_error">Errore sconosciuto</string>
   <string name="git_pull_rebase_fail_error">Pull non è riuscito, sei in un capo distaccato. Usando \"impostazioni e utilità di git\", salvi le tue modifiche in remoto in un nuovo ramo e risolvi il conflitto sul tuo computer.</string>
@@ -267,7 +267,7 @@
   <string name="git_operation_running">Eseguendo l\'operazione di git…</string>
   <string name="git_break_out_of_detached_success">Si è verificato un conflitto provando a ricollocare. Il tuo ramo locale %1$s è stato premuto all\'altro ramo denominato %2$s\n Usa questo ramo per risolvere il conflitto sul tuo computer</string>
   <string name="git_break_out_of_detached_unneeded">La repository non si sta ricollocando, nessun bisogno di spingere all\'altro ramo</string>
-  <!-- GPG key selection in folder creation -->
+  <!-- PGP key selection in folder creation -->
   <string name="folder_creation_err_file_exists">Un file con quel nome esiste già</string>
   <string name="folder_creation_err_folder_exists">Una cartella con quel nome esiste già</string>
   <!-- Onboarding flow -->
@@ -276,8 +276,8 @@
   <string name="select_repo_type_text">Seleziona se vuoi creare una repo locale o clonarne una remota.</string>
   <string name="clone_remote_repo">Clona Repo Remota</string>
   <string name="create_local_repo">Crea Repo Locale</string>
-  <string name="select_gpg_key_title">Seleziona\nChiave\nGPG</string>
-  <string name="select_gpg_key_message">Seleziona una chiave GPG con cui inizializzare il tuo archivio</string>
+  <string name="select_gpg_key_title">Seleziona\nChiave\nPGP</string>
+  <string name="select_gpg_key_message">Seleziona una chiave PGP con cui inizializzare il tuo archivio</string>
   <string name="gpg_key_select">Seleziona chiave</string>
   <!-- SSH port validation -->
   <string name="ssh_scheme_needed_title">URL potenzialmente errato</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -34,7 +34,7 @@
   <string name="git_commit_remove_text">%1$s 을 저장소에서 삭제하였습니다.</string>
   <string name="git_commit_move_text">%1$s 의 이름을 %2$s 로 변경하였습니다.</string>
   <string name="git_commit_move_multiple_text">여러개의 비밀번호를 %1$s 로 옮겼습니다.</string>
-  <string name="git_commit_gpg_id">%1$s의 GPG ID를 초기화 합니다.</string>
+  <string name="git_commit_gpg_id">%1$s의 PGP ID를 초기화 합니다.</string>
   <!-- PGPHandler -->
   <string name="clipboard_copied_text">클립보드로 복사됨</string>
   <string name="file_toast_text">파일 이름이 필요합니다</string>
@@ -114,7 +114,7 @@
   <string name="pref_rebase_on_pull_summary_on">Pull 하거나 동기화 할 때, 현재 원격 저장소에 있지 않은 commit을 Rebase 합니다.</string>
   <string name="pref_disable_sync_on_pull_title">동기화 시 pull 비활성화</string>
   <string name="pref_disable_sync_on_pull_summary">Git 동기화 할 때 암호 목록을 pull 하는 것을 방지합니다</string>
-  <string name="pref_import_pgp_key_title">GPG 키 가져오기</string>
+  <string name="pref_import_pgp_key_title">PGP 키 가져오기</string>
   <string name="pref_pgp_key_manager_title">키 관리자</string>
   <string name="pref_pgp_ascii_armor_title">ASCII armor 모드로 암호화</string>
   <!-- PasswordGenerator fragment -->
@@ -268,11 +268,10 @@ username@example.com:…</string>
   <string name="otp_import_failure_generic">TOTP 구성을 가져오지 못했습니다.</string>
   <string name="otp_import_failure_no_selection">선택한 이미지 파일이 없습니다</string>
   <string name="exporting_passwords">비밀번호 내보내는 중…</string>
-  <string name="invalid_gpg_id">.gpg-id를 찾았지만 잘못된 키 ID, 지문 또는 사용자 ID가 포함되어 있습니다</string>
   <string name="short_gpg_id">.gpg-id를 찾았지만, 지원되지 않는 짧은 16진수 ID가 포함되어 있습니다.</string>
   <string name="invalid_filename_text">파일 이름에 \'/\'가 포함되어서는 안됩니다. 위의 디렉터리를 설정하세요</string>
   <string name="directory_hint">디렉토리</string>
-  <string name="new_folder_set_gpg_key">디렉토리의 GPG 키 설정</string>
+  <string name="new_folder_set_gpg_key">디렉토리의 PGP 키 설정</string>
   <!-- GitException messages -->
   <string name="git_unknown_error">알 수 없는 오류</string>
   <string name="git_pull_rebase_fail_error">풀이 실패하여 head가 분리된 상태입니다. \"설정 &gt; git 기능\"을 사용하여 원격 저장소에 변경 내용을 새 브랜치에 저장하고 컴퓨터에서 충돌을 해결하세요.</string>
@@ -284,8 +283,8 @@ username@example.com:…</string>
   <string name="git_operation_running">Git 작업 실행 중…</string>
   <string name="git_break_out_of_detached_success">리베이스하는 동안 충돌이 발생했습니다. 로컬 %1$s 브랜치가 %2$s이라는 다른 브랜치로 푸시되었습니다.\n이 브랜치를 사용하여 컴퓨터에서 충돌을 해결하세요.</string>
   <string name="git_break_out_of_detached_unneeded">이 저장소는 리베이스가 아니므로 다른 브랜치로 푸시할 필요가 없습니다.</string>
-  <!-- GPG key selection in folder creation -->
-  <string name="gpg_key_select_mandatory">계속하려면 GPG 키를 선택해야 합니다</string>
+  <!-- PGP key selection in folder creation -->
+  <string name="gpg_key_select_mandatory">계속하려면 PGP 키를 선택해야 합니다</string>
   <string name="folder_creation_err_file_exists">동일한 이름의 파일이 이미 있습니다</string>
   <string name="folder_creation_err_folder_exists">이 이름의 폴더가 이미 존재합니다</string>
   <!-- Onboarding flow -->
@@ -294,8 +293,8 @@ username@example.com:…</string>
   <string name="select_repo_type_text">로컬 리포지토리를 만들 것인지, 원격 리포지토리를 복제할 것인지 선택합니다.</string>
   <string name="clone_remote_repo">원격 저장소 복제</string>
   <string name="create_local_repo">로컬 저장소 생성</string>
-  <string name="select_gpg_key_title">GPG 키\n선택</string>
-  <string name="select_gpg_key_message">스토어를 초기화할 GPG 키를 선택합니다</string>
+  <string name="select_gpg_key_title">PGP 키\n선택</string>
+  <string name="select_gpg_key_message">스토어를 초기화할 PGP 키를 선택합니다</string>
   <string name="gpg_key_select">키 선택</string>
   <!-- SSH port validation -->
   <string name="ssh_scheme_needed_title">잠재적으로 잘못된 URL</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -260,11 +260,11 @@
   <string name="add_otp">Dodaj OTP</string>
   <string name="otp_import_success">Pomyślnie zaimportowano konfigurację TOTP</string>
   <string name="exporting_passwords">Eksportowanie haseł…</string>
-  <string name="invalid_gpg_id">Znaleziono .gpg-id, ale zawiera nieprawidłowy identyfikator klucza, odcisk palca lub identyfikator użytkownika</string>
+  <string name="invalid_gpg_id">Znaleziono plik .gpg-id, ale zawiera on nieprawidłowy lub nieznany identyfikator klucza.</string>
   <string name="short_gpg_id">Znaleziono .gpg-id, ale zawarty w nim skrócony identyfikator nie jest obsługiwany</string>
   <string name="invalid_filename_text">Nazwa pliku nie może zawierać \'/\', ustaw katalog powyżej</string>
   <string name="directory_hint">Katalog</string>
-  <string name="new_folder_set_gpg_key">Ustaw klucz GPG dla katalogu</string>
+  <string name="new_folder_set_gpg_key">Ustaw klucz PGP dla katalogu</string>
   <!-- GitException messages -->
   <string name="git_unknown_error">Nieznany błąd</string>
   <string name="git_pull_rebase_fail_error">Zaciąganie zmian nie powiodło się, nie jesteś na żadnej gałęzi (detached head). Używając \"Ustawienia &gt; narzędzia Git\", wyślij lokalne zmiany do zdalnego repozytorium na nowej gałęzi i rozwiąż konflikt na komputerze.</string>
@@ -276,7 +276,7 @@
   <string name="git_operation_running">Operacja Git w toku…</string>
   <string name="git_break_out_of_detached_success">Podczas operacji \"rebase\" wystąpił konflikt. Twoja lokalna gałąź %1$s została przepchnięta do innej gałęzi o nazwie %2$s\n Użyj tej gałęzi do rozwiązania konfliktu na komputerze</string>
   <string name="git_break_out_of_detached_unneeded">Repozytorium nie jest w trakcie operacji \"rebase\", nie ma potrzeby wypychać do innej gałęzi</string>
-  <!-- GPG key selection in folder creation -->
+  <!-- PGP key selection in folder creation -->
   <string name="folder_creation_err_file_exists">Plik o tej nazwie już istnieje</string>
   <string name="folder_creation_err_folder_exists">Folder o tej nazwie już istnieje</string>
   <!-- Onboarding flow -->
@@ -285,8 +285,8 @@
   <string name="select_repo_type_text">Zaznacz, czy chcesz utworzyć lokalne repozytorium, czy sklonować zdalne repozytorium.</string>
   <string name="clone_remote_repo">Klonuj zdalne repozytorium</string>
   <string name="create_local_repo">Utwórz lokalne repozytorium</string>
-  <string name="select_gpg_key_title">Wybierz\nklucz GPG</string>
-  <string name="select_gpg_key_message">Wybierz klucz GPG, którym zainicjować swoje repozytorium</string>
+  <string name="select_gpg_key_title">Wybierz\nklucz PGP</string>
+  <string name="select_gpg_key_message">Wybierz klucz PGP, którym zainicjować swoje repozytorium</string>
   <string name="gpg_key_select">Wybierz klucz</string>
   <!-- SSH port validation -->
   <string name="ssh_scheme_needed_title">Potencjalnie nieprawidłowy adres URL</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -36,7 +36,7 @@
   <string name="git_commit_remove_text">Remova %1$s do armazenamento.</string>
   <string name="git_commit_move_text">Renomear %1$s para %2$s.</string>
   <string name="git_commit_move_multiple_text">Mova múltiplas senhas para %1$s.</string>
-  <string name="git_commit_gpg_id">Inicializar IDs GPG em %1$s.</string>
+  <string name="git_commit_gpg_id">Inicializar IDs PGP em %1$s.</string>
   <!-- PGPHandler -->
   <string name="clipboard_copied_text">Copiado para a área de transferência</string>
   <string name="file_toast_text">Por favor, informe um nome de arquivo</string>
@@ -267,11 +267,11 @@
   <string name="otp_import_failure_generic">Falha ao importar a configuração TOTP</string>
   <string name="otp_import_failure_no_selection">Nenhum arquivo de imagem foi selecionado</string>
   <string name="exporting_passwords">Exportando senhas…</string>
-  <string name="invalid_gpg_id">Encontrado .gpg-id, mas contém um ID de chave, fingerprint ou ID de usuário inválidos</string>
-  <string name="short_gpg_id">Encontrado .gpg-id, mas contém uma ID hexadecimal curta, que não é suportada</string>
+  <string name="invalid_gpg_id">O arquivo .gpg-id foi encontrado, mas contém um ID de chave inválido ou desconhecido.</string>
+  <string name="short_gpg_id">O arquivo .gpg-id foi encontrado, mas contém uma ID hexadecimal curta, que não é suportada.</string>
   <string name="invalid_filename_text">Nome do arquivo não deve conter \'/\', defina o diretório acima</string>
   <string name="directory_hint">Diretório</string>
-  <string name="new_folder_set_gpg_key">Definir chave GPG para diretório</string>
+  <string name="new_folder_set_gpg_key">Definir chave PGP para diretório</string>
   <!-- GitException messages -->
   <string name="git_unknown_error">Erro desconhecido</string>
   <string name="git_pull_rebase_fail_error">O pull falhou, você está em uma Head avulsa. Usando \"configurações &gt; utils\" do git, salve suas alterações no remoto em uma nova branch e resolva o conflito no seu computador.</string>
@@ -283,8 +283,8 @@
   <string name="git_operation_running">Executando operação do git…</string>
   <string name="git_break_out_of_detached_success">Houve um conflito ao executar o rebase. Houve um push de branch %1$s local para outra branch chamada %2$s\n Use esta branch para resolver o conflito no seu computador</string>
   <string name="git_break_out_of_detached_unneeded">O repositório não está sendo rebased, não há necessidade de fazer push para outro branch</string>
-  <!-- GPG key selection in folder creation -->
-  <string name="gpg_key_select_mandatory">A seleção de uma chave GPG é necessária para prosseguir</string>
+  <!-- PGP key selection in folder creation -->
+  <string name="gpg_key_select_mandatory">A seleção de uma chave PGP é necessária para prosseguir</string>
   <string name="folder_creation_err_file_exists">Já existe um arquivo com esse nome</string>
   <string name="folder_creation_err_folder_exists">Já existe uma pasta com esse nome</string>
   <!-- Onboarding flow -->
@@ -293,8 +293,8 @@
   <string name="select_repo_type_text">Selecione se você quer criar um repositório local ou clonar um repositório remoto.</string>
   <string name="clone_remote_repo">Clonar repositório remoto</string>
   <string name="create_local_repo">Criar repositório local</string>
-  <string name="select_gpg_key_title">Selecione\nChave GPG</string>
-  <string name="select_gpg_key_message">Selecione uma chave GPG para inicializar o armazenamento com</string>
+  <string name="select_gpg_key_title">Selecione\nChave PGP</string>
+  <string name="select_gpg_key_message">Selecione uma chave PGP para inicializar o armazenamento com</string>
   <string name="gpg_key_select">Selecione a chave</string>
   <!-- SSH port validation -->
   <string name="ssh_scheme_needed_title">URL potencialmente incorreta</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -40,7 +40,7 @@
   <string name="git_commit_remove_text">Удалить %1$s из хранилища.</string>
   <string name="git_commit_move_text">Переименовать %1$s в %2$s.</string>
   <string name="git_commit_move_multiple_text">Переместить несколько паролей в %1$s.</string>
-  <string name="git_commit_gpg_id">Инициализация GPG ID через %1$s.</string>
+  <string name="git_commit_gpg_id">Инициализация PGP ID через %1$s.</string>
   <!-- PGPHandler -->
   <string name="clipboard_copied_text">Скопировано в буфер обмена</string>
   <string name="file_toast_text">Пожалуйста, укажите имя файла</string>
@@ -264,10 +264,10 @@
   <string name="otp_import_failure_generic">Не удалось импортировать конфигурацию TOTP</string>
   <string name="otp_import_failure_no_selection">Не выбран файл изображения</string>
   <string name="exporting_passwords">Экспорт паролей…</string>
-  <string name="invalid_gpg_id">Найден .gpg-id, но он содержит неверный ID ключа, fingerprint или ID пользователя</string>
+  <string name="invalid_gpg_id">Файл .gpg-id найден, но содержит неверный или неизвестный идентификатор ключа.</string>
   <string name="invalid_filename_text">Имя файла не должно содержать \'/\', укажите директорию выше</string>
   <string name="directory_hint">Директория</string>
-  <string name="new_folder_set_gpg_key">Установить GPG ключ для каталога</string>
+  <string name="new_folder_set_gpg_key">Установить PGP ключ для каталога</string>
   <!-- GitException messages -->
   <string name="git_unknown_error">Неизвестная ошибка</string>
   <string name="git_pull_rebase_fail_error">Не удалось получить изменения, вы находитесь в состоянии \"оторванной головы\". Используйте \"настройки &gt; утилиты git\", сохраните ваши изменения в новую удаленную ветку и разрешите конфликты на своем компьютере.</string>
@@ -279,8 +279,8 @@
   <string name="git_operation_running">Выполнение операции git…</string>
   <string name="git_break_out_of_detached_success">При попытке rebase\'а возник конфликт. Ваша локальная ветка %1$s была запушена %2$s\n Используйте эту ветку для разрешения конфликтов с помощью компьютера</string>
   <string name="git_break_out_of_detached_unneeded">Не нужно пушить в другую ветку - rebase не был запущен</string>
-  <!-- GPG key selection in folder creation -->
-  <string name="gpg_key_select_mandatory">Для продолжения необходимо выбрать GPG-ключ</string>
+  <!-- PGP key selection in folder creation -->
+  <string name="gpg_key_select_mandatory">Для продолжения необходимо выбрать PGP-ключ</string>
   <string name="folder_creation_err_file_exists">Файл с таким именем уже существует</string>
   <string name="folder_creation_err_folder_exists">Папка с таким именем уже существует</string>
   <!-- Onboarding flow -->
@@ -289,8 +289,8 @@
   <string name="select_repo_type_text">Создать локальное хранилище, или клонировать удаленный репозиторий.</string>
   <string name="clone_remote_repo">Клонировать удаленный репозиторий</string>
   <string name="create_local_repo">Создать локальное хранилище</string>
-  <string name="select_gpg_key_title">Выберите\nGPG ключ</string>
-  <string name="select_gpg_key_message">Выберите GPG ключ для инициализации хранилища</string>
+  <string name="select_gpg_key_title">Выберите\nPGP ключ</string>
+  <string name="select_gpg_key_message">Выберите PGP ключ для инициализации хранилища</string>
   <string name="gpg_key_select">Выберите ключ</string>
   <!-- SSH port validation -->
   <string name="ssh_scheme_needed_title">Потенциально неправильный URL</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -35,7 +35,7 @@
   <string name="git_commit_remove_text">从仓库中删除%1$s</string>
   <string name="git_commit_move_text">将%1$s重命名为%2$s</string>
   <string name="git_commit_move_multiple_text">将多个密码移至%1$s</string>
-  <string name="git_commit_gpg_id">初始化 %1$s 中的 GPG ID</string>
+  <string name="git_commit_gpg_id">初始化 %1$s 中的 PGP ID</string>
   <!-- PGPHandler -->
   <string name="clipboard_copied_text">复制到剪切板</string>
   <string name="file_toast_text">请提供文件名</string>
@@ -271,11 +271,10 @@ personal.com</string>
   <string name="otp_import_failure_generic">导入TOTP配置失败</string>
   <string name="otp_import_failure_no_selection">没有选择镜像文件</string>
   <string name="exporting_passwords">正在导出密码…</string>
-  <string name="invalid_gpg_id">找到了 .gpg-id，但它包含无效的密钥ID、指纹或用户ID</string>
   <string name="short_gpg_id">找到 .gpg-id 但它包含一个不受支持的短十六进制ID。</string>
   <string name="invalid_filename_text">文件名不能包含\'/\'</string>
   <string name="directory_hint">目录</string>
-  <string name="new_folder_set_gpg_key">为目录设置GPG密钥</string>
+  <string name="new_folder_set_gpg_key">为目录设置PGP密钥</string>
   <!-- GitException messages -->
   <string name="git_unknown_error">未知错误</string>
   <string name="git_pull_merge_fail_error">合并失败，你处于冲突状态。TODO：添加恢复方法。</string>
@@ -287,8 +286,8 @@ personal.com</string>
   <string name="git_break_out_of_detached_success">尝试变更时发生冲突,您的本地%1$s分支被推送到另一个名为%2$s的分支
 使用此分支解决计算机上的冲突</string>
   <string name="git_break_out_of_detached_unneeded">存储库没有变更,无需推送到另一个分支</string>
-  <!-- GPG key selection in folder creation -->
-  <string name="gpg_key_select_mandatory">选择一个 GPG 密钥才能继续</string>
+  <!-- PGP key selection in folder creation -->
+  <string name="gpg_key_select_mandatory">选择一个 PGP 密钥才能继续</string>
   <string name="folder_creation_err_file_exists">该名称的文件已存在</string>
   <string name="folder_creation_err_folder_exists">该名称的文件夹已存在</string>
   <!-- Onboarding flow -->
@@ -298,9 +297,9 @@ personal.com</string>
   <string name="clone_remote_repo">同步远程仓库</string>
   <string name="create_local_repo">创建本地仓库</string>
   <string name="select_gpg_key_title">选择
-GPG
+PGP
 密钥</string>
-  <string name="select_gpg_key_message">选择一个GPG密钥来初始化您的仓库</string>
+  <string name="select_gpg_key_message">选择一个PGP密钥来初始化您的仓库</string>
   <string name="gpg_key_select">选择密钥</string>
   <!-- SSH port validation -->
   <string name="ssh_scheme_needed_title">URL可能不正确</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,7 +43,7 @@
   <string name="git_commit_remove_text">Remove %1$s from store.</string>
   <string name="git_commit_move_text">Rename %1$s to %2$s.</string>
   <string name="git_commit_move_multiple_text">Move multiple passwords to %1$s.</string>
-  <string name="git_commit_gpg_id">Initialize GPG IDs in %1$s.</string>
+  <string name="git_commit_gpg_id">Initialize PGP IDs in %1$s.</string>
 
   <!-- PGPHandler -->
   <string name="clipboard_copied_text">Copied to clipboard</string>
@@ -299,13 +299,13 @@
   <string name="otp_import_failure_generic">Failed to import TOTP configuration</string>
   <string name="otp_import_failure_no_selection">No image file was selected</string>
   <string name="exporting_passwords">Exporting passwords…</string>
-  <string name="invalid_gpg_id">Found .gpg-id, but it contains an invalid key ID, fingerprint or user ID</string>
+  <string name="invalid_gpg_id">Found .gpg-id, but it contains an invalid or unknown key ID.</string>
   <string name="empty_gpg_id">Found .gpg-id, but it is empty.</string>
   <string name="missing_gpg_id">No .gpg-id could be found.</string>
-  <string name="short_gpg_id">Found .gpg-id, but it contains a short hex ID, which is not supported</string>
-  <string name="invalid_filename_text">File name must not contain \'/\', set directory above</string>
+  <string name="short_gpg_id">Found .gpg-id, but it contains a short hex ID, which is not supported.</string>
+  <string name="invalid_filename_text">File name must not contain \'/\', set directory above.</string>
   <string name="directory_hint">Directory</string>
-  <string name="new_folder_set_gpg_key">Set GPG key for directory</string>
+  <string name="new_folder_set_gpg_key">Set PGP key for directory</string>
 
   <!-- GitException messages -->
   <string name="git_unknown_error">Unknown error</string>
@@ -320,8 +320,8 @@
   <string name="git_break_out_of_detached_success">There was a conflict when trying to rebase. Your local %1$s branch was pushed to another branch named %2$s\n Use this branch to resolve conflict on your computer</string>
   <string name="git_break_out_of_detached_unneeded">The repository is not rebasing, no need to push to another branch</string>
 
-  <!-- GPG key selection in folder creation -->
-  <string name="gpg_key_select_mandatory">Selecting a GPG key is necessary to proceed</string>
+  <!-- PGP key selection in folder creation -->
+  <string name="gpg_key_select_mandatory">Selecting a PGP key is necessary to proceed</string>
   <string name="folder_creation_err_file_exists">A file by that name already exists</string>
   <string name="folder_creation_err_folder_exists">A folder by that name already exists</string>
 
@@ -331,8 +331,8 @@
   <string name="select_repo_type_text">Select if you want to create a local repo or clone a remote repo.</string>
   <string name="clone_remote_repo">Clone Remote Repo</string>
   <string name="create_local_repo">Create Local Repo</string>
-  <string name="select_gpg_key_title">Select\nGPG Key</string>
-  <string name="select_gpg_key_message">Select a GPG key to initialize your store with</string>
+  <string name="select_gpg_key_title">Select\nPGP Key</string>
+  <string name="select_gpg_key_message">Select a PGP key to initialize your store with</string>
   <string name="gpg_key_select">Select key</string>
 
   <!-- SSH port validation -->


### PR DESCRIPTION
A missing or invalid `.gpg-id` file causes the app to crash. The related original repo's issue is https://github.com/android-password-store/Android-Password-Store/issues/3227. This PR fixes the issue. Now, the user is prompted for re-selecting / re-importing a PGP secret key file.