### PR TITLE
"Import SSH key" option always visible in Repository settings

### DIFF
--- a/app/src/main/java/app/passwordstore/ui/settings/RepositorySettings.kt
+++ b/app/src/main/java/app/passwordstore/ui/settings/RepositorySettings.kt
@@ -92,7 +92,6 @@ class RepositorySettings(private val activity: FragmentActivity) : SettingsProvi
       }
       pref(PreferenceKeys.SSH_KEY) {
         titleRes = R.string.pref_import_ssh_key_title
-        visible = PasswordRepository.isGitRepo()
         onClick {
           activity.launchActivity(SshKeyImportActivity::class.java)
           true


### PR DESCRIPTION
Option "Import SSH key" was not visible in the Settings -> Repository menu of a fresh APS install.