### PR TITLE
use KTX extension function String.toUri

### DIFF
--- a/app/src/main/java/app/passwordstore/ui/settings/AutofillSettings.kt
+++ b/app/src/main/java/app/passwordstore/ui/settings/AutofillSettings.kt
@@ -7,9 +7,9 @@ package app.passwordstore.ui.settings
 
 import android.annotation.SuppressLint
 import android.content.Intent
-import android.net.Uri
 import android.provider.Settings
 import androidx.appcompat.widget.AppCompatTextView
+import androidx.core.net.toUri
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -73,7 +73,7 @@ class AutofillSettings(private val activity: FragmentActivity) : SettingsProvide
       setPositiveButton(R.string.dialog_ok) { _, _ ->
         val intent =
           Intent(Settings.ACTION_REQUEST_SET_AUTOFILL_SERVICE).apply {
-            data = Uri.parse("package:${BuildConfig.APPLICATION_ID}")
+            data = "package:${BuildConfig.APPLICATION_ID}".toUri()
           }
         activity.startActivity(intent)
       }

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillFormParser.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillFormParser.kt
@@ -8,11 +8,11 @@ import android.app.assist.AssistStructure
 import android.content.Context
 import android.content.pm.PackageManager
 import android.content.pm.PackageManager.ApplicationInfoFlags
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.view.autofill.AutofillId
 import androidx.annotation.RequiresApi
+import androidx.core.net.toUri
 import logcat.logcat
 
 /**
@@ -150,7 +150,8 @@ private class AutofillFormParser(
   }
 
   private fun webOriginToFormOrigin(context: Context, origin: String): FormOrigin? {
-    val uri = Uri.parse(origin) ?: return null
+    val uri = origin.toUri()
+
     val scheme = uri.scheme ?: return null
     if (scheme !in SUPPORTED_SCHEMES) return null
     val host = uri.host ?: return null

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
@@ -8,11 +8,11 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.PackageManager.ResolveInfoFlags
-import android.net.Uri
 import android.os.Build
 import android.provider.Settings
 import android.service.autofill.SaveInfo
 import androidx.annotation.RequiresApi
+import androidx.core.net.toUri
 
 /**
  * In order to add a new browser, do the following:
@@ -244,7 +244,7 @@ private fun getBrowserAutofillSupportLevel(
 public fun getInstalledBrowsersWithAutofillSupportLevel(
   context: Context
 ): List<Pair<String, BrowserAutofillSupportLevel>> {
-  val testWebIntent = Intent(Intent.ACTION_VIEW).apply { data = Uri.parse("https://example.org") }
+  val testWebIntent = Intent(Intent.ACTION_VIEW).apply { data = "https://example.org".toUri() }
   val installedBrowsers =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
       context.packageManager.queryIntentActivities(


### PR DESCRIPTION
Use KTX extension function for URI parsing in autofill-parser. Fixes lint failure during shadow job.