### PR TITLE
fix app crash after aborted clone operation

### DIFF
--- a/app/src/main/java/app/passwordstore/ui/onboarding/fragments/CloneFragment.kt
+++ b/app/src/main/java/app/passwordstore/ui/onboarding/fragments/CloneFragment.kt
@@ -22,7 +22,6 @@ import app.passwordstore.util.extensions.unsafeLazy
 import app.passwordstore.util.extensions.viewBinding
 import app.passwordstore.util.settings.PreferenceKeys
 import com.github.michaelbull.result.onFailure
-import com.github.michaelbull.result.onSuccess
 import com.github.michaelbull.result.runCatching
 import java.io.File
 import logcat.LogPriority.ERROR
@@ -38,8 +37,17 @@ class CloneFragment : Fragment(R.layout.fragment_clone) {
   private val cloneAction =
     registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
       if (result.resultCode == AppCompatActivity.RESULT_OK) {
-        settings.edit { putBoolean(PreferenceKeys.REPOSITORY_INITIALIZED, true) }
-        finish()
+        if (File(PasswordRepository.getRepositoryDirectory(), ".gpg-id").exists()) {
+          settings.edit { putBoolean(PreferenceKeys.REPOSITORY_INITIALIZED, true) }
+          finish()
+        } else {
+          runCatching {
+              parentFragmentManager.performTransactionWithBackStack(
+                KeySelectionFragment.newInstance()
+              )
+            }
+            .onFailure { e -> logcat(ERROR) { e.asLog() } }
+        }
       }
     }
 
@@ -51,19 +59,7 @@ class CloneFragment : Fragment(R.layout.fragment_clone) {
 
   /** Clones a remote Git repository to the app's private directory */
   private fun cloneToHiddenDir() {
-    runCatching { cloneAction.launch(GitServerConfigActivity.createCloneIntent(requireContext())) }
-      .onSuccess {
-        val gpgIdentifierFile = File(PasswordRepository.getRepositoryDirectory(), ".gpg-id")
-        if (!gpgIdentifierFile.exists()) {
-          runCatching {
-              parentFragmentManager.performTransactionWithBackStack(
-                KeySelectionFragment.newInstance()
-              )
-            }
-            .onFailure { e -> logcat(ERROR) { e.asLog() } }
-        }
-      }
-      .onFailure { e -> logcat(ERROR) { e.asLog() } }
+    cloneAction.launch(GitServerConfigActivity.createCloneIntent(requireContext()))
   }
 
   private fun createRepository() {


### PR DESCRIPTION
During onboarding, although the user aborts the clone operation, the PGP key selection dialog opens. If the user imports and selects a PGP key, the app will crash because it tries to write `.gpg-id` into the yet non-existing repo dir. This PR fixes the issue: When aborting the clone operation, the app returns to the previous dialog instead of prompting for the key selection.