### PR TITLE
optional setting a PGP key for new sub-folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+-   Allow setting a subdirectory PGP key when creating folders (restored feature from [1.11.0])
+
 ### Fixed
+
 -   Auto-dismiss an abandoned password edit dialog after configurable timeout (password copy timeout is used if configured, 60 seconds otherwise) to prevent information leakage
 -   Initialising an empty cloned non-pass repo is now possible. The repo to be cloned should however already have at least one commit, e. g. an added and removed dummy file
 -   Fix app crashes due to `.gpg-id` with invalid or unknown key/user ID. Prompt for re-selecting/re-importing a PGP secret key file.
 
 ### Changed
+
 -   **BREAKING**: The option for generating the SSH key pair in the Ed25519 format was removed from APS. It relied on the now deprecated `androidx.security:security-crypto` library to store the private key as an encrypted file in the application's hidden directory. Use one of Android KeyStore native RSA or ECDSA key format options when generating the SSH key pair. Alternatively, an externally generated SSH private key can be imported into the app. Imported SSH private keys can be in any format, including Ed25519, but they should be protected with a passphrase
 -   **BREAKING**: Non-free variant removed which allowed filling OTP fields with codes sent by SMS
 -   `.gpg-id` is now initialised with the numeric key ID instead of the user ID (email)

--- a/app/src/main/java/app/passwordstore/ui/dialogs/FolderCreationDialogFragment.kt
+++ b/app/src/main/java/app/passwordstore/ui/dialogs/FolderCreationDialogFragment.kt
@@ -5,21 +5,47 @@
 package app.passwordstore.ui.dialogs
 
 import android.app.Dialog
+import android.content.Intent
 import android.os.Bundle
 import android.view.WindowManager
+import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import app.passwordstore.R
 import app.passwordstore.ui.passwords.PasswordStore
+import app.passwordstore.ui.pgp.PGPKeyListActivity
+import app.passwordstore.util.extensions.commitChange
+import com.google.android.material.checkbox.MaterialCheckBox
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import java.io.File
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 class FolderCreationDialogFragment : DialogFragment() {
 
   private lateinit var newFolder: File
+
+  private val gpgKeySelectAction =
+    registerForActivityResult(StartActivityForResult()) { result ->
+      if (result.resultCode == AppCompatActivity.RESULT_OK) {
+        val data = result.data ?: return@registerForActivityResult
+        val selectedKeyId =
+          data.getStringExtra(PGPKeyListActivity.EXTRA_SELECTED_KEY)
+            ?: return@registerForActivityResult
+        runBlocking {
+          val gpgIdentifierFile = File(newFolder, ".gpg-id")
+          gpgIdentifierFile.writeText(selectedKeyId)
+          requireActivity()
+            .commitChange(getString(R.string.git_commit_gpg_id, getString(R.string.app_name)))
+        }
+        (requireActivity() as PasswordStore).refreshPasswordList(newFolder)
+      }
+      dismiss()
+    }
 
   override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
     val alertDialogBuilder = MaterialAlertDialogBuilder(requireContext())
@@ -52,16 +78,13 @@ class FolderCreationDialogFragment : DialogFragment() {
       }
     if (folderNameViewContainer.error != null) return
     newFolder.mkdirs()
+    if (dialog.findViewById<MaterialCheckBox>(R.id.set_gpg_key).isChecked) {
+      val intent = Intent(requireContext(), PGPKeyListActivity::class.java)
+      intent.putExtra(PGPKeyListActivity.EXTRA_KEY_SELECTION, true)
+      gpgKeySelectAction.launch(intent)
+      return
+    }
     (requireActivity() as PasswordStore).refreshPasswordList(newFolder)
-    // TODO(msfjarvis): Restore this functionality
-    /*
-        if (dialog.findViewById<MaterialCheckBox>(R.id.set_gpg_key).isChecked) {
-          keySelectAction.launch(Intent(requireContext(), GetKeyIdsActivity::class.java))
-          return
-        } else {
-          dismiss()
-        }
-    */
     dismiss()
   }
 

--- a/app/src/main/java/app/passwordstore/ui/onboarding/fragments/KeySelectionFragment.kt
+++ b/app/src/main/java/app/passwordstore/ui/onboarding/fragments/KeySelectionFragment.kt
@@ -14,48 +14,36 @@ import androidx.core.content.edit
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import app.passwordstore.R
-import app.passwordstore.crypto.PGPIdentifier
-import app.passwordstore.crypto.PGPKeyManager
 import app.passwordstore.data.repo.PasswordRepository
 import app.passwordstore.databinding.FragmentKeySelectionBinding
 import app.passwordstore.injection.prefs.SettingsPreferences
 import app.passwordstore.ui.pgp.PGPKeyListActivity
-import app.passwordstore.util.coroutines.DispatcherProvider
 import app.passwordstore.util.extensions.commitChange
 import app.passwordstore.util.extensions.finish
 import app.passwordstore.util.extensions.snackbar
 import app.passwordstore.util.extensions.viewBinding
 import app.passwordstore.util.settings.PreferenceKeys
-import com.github.michaelbull.result.unwrap
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.File
 import javax.inject.Inject
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 @AndroidEntryPoint
 class KeySelectionFragment : Fragment(R.layout.fragment_key_selection) {
 
-  @Inject lateinit var pgpKeyManager: PGPKeyManager
   @Inject @SettingsPreferences lateinit var settings: SharedPreferences
-  @Inject lateinit var dispatcherProvider: DispatcherProvider
   private val binding by viewBinding(FragmentKeySelectionBinding::bind)
   private val gpgKeySelectAction =
     registerForActivityResult(StartActivityForResult()) { result ->
       if (result.resultCode == AppCompatActivity.RESULT_OK) {
         val data = result.data ?: return@registerForActivityResult
-        val selectedUserId =
+        val selectedKeyId =
           data.getStringExtra(PGPKeyListActivity.EXTRA_SELECTED_KEY)
             ?: return@registerForActivityResult
-        val pgpUserId = PGPIdentifier.fromString(selectedUserId) ?: return@registerForActivityResult
         lifecycleScope.launch {
-          withContext(dispatcherProvider.io()) {
-            val key = pgpKeyManager.getKeyById(pgpUserId).unwrap()
-            val keyId = pgpKeyManager.getKeyId(key) ?: throw NullPointerException()
-            val gpgIdentifierFile = File(PasswordRepository.gpgidCurPath, ".gpg-id")
-            gpgIdentifierFile.writeText(keyId.toString())
-          }
+          val gpgIdentifierFile = File(PasswordRepository.gpgidCurPath, ".gpg-id")
+          gpgIdentifierFile.writeText(selectedKeyId)
           settings.edit { putBoolean(PreferenceKeys.REPOSITORY_INITIALIZED, true) }
           requireActivity()
             .commitChange(getString(R.string.git_commit_gpg_id, getString(R.string.app_name)))

--- a/app/src/main/java/app/passwordstore/ui/passwords/PasswordStore.kt
+++ b/app/src/main/java/app/passwordstore/ui/passwords/PasswordStore.kt
@@ -24,8 +24,6 @@ import androidx.fragment.app.commit
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import app.passwordstore.R
-import app.passwordstore.crypto.PGPIdentifier
-import app.passwordstore.crypto.PGPKeyManager
 import app.passwordstore.data.password.PasswordItem
 import app.passwordstore.data.repo.PasswordRepository
 import app.passwordstore.ui.crypto.BasePGPActivity
@@ -54,7 +52,6 @@ import app.passwordstore.util.viewmodel.SearchableRepositoryViewModel
 import com.github.michaelbull.result.fold
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.runCatching
-import com.github.michaelbull.result.unwrap
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
 import dagger.hilt.android.AndroidEntryPoint
@@ -73,7 +70,6 @@ const val PASSWORD_FRAGMENT_TAG = "PasswordsList"
 @AndroidEntryPoint
 class PasswordStore : BaseGitActivity() {
 
-  @Inject lateinit var pgpKeyManager: PGPKeyManager
   @Inject lateinit var shortcutHandler: ShortcutHandler
   private lateinit var searchItem: MenuItem
   private val settings by lazy { sharedPrefs }
@@ -84,17 +80,12 @@ class PasswordStore : BaseGitActivity() {
     registerForActivityResult(StartActivityForResult()) { result ->
       if (result.resultCode == AppCompatActivity.RESULT_OK) {
         val data = result.data ?: return@registerForActivityResult
-        val selectedUserId =
+        val selectedKeyId =
           data.getStringExtra(PGPKeyListActivity.EXTRA_SELECTED_KEY)
             ?: return@registerForActivityResult
-        val pgpUserId = PGPIdentifier.fromString(selectedUserId) ?: return@registerForActivityResult
         runBlocking {
-          withContext(dispatcherProvider.io()) {
-            val key = pgpKeyManager.getKeyById(pgpUserId).unwrap()
-            val keyId = pgpKeyManager.getKeyId(key) ?: throw NullPointerException()
-            val gpgIdentifierFile = File(PasswordRepository.gpgidCurPath, ".gpg-id")
-            gpgIdentifierFile.writeText(keyId.toString())
-          }
+          val gpgIdentifierFile = File(PasswordRepository.gpgidCurPath, ".gpg-id")
+          gpgIdentifierFile.writeText(selectedKeyId)
           commitChange(getString(R.string.git_commit_gpg_id, getString(R.string.app_name)))
         }
         refreshPasswordList()

--- a/app/src/main/java/app/passwordstore/ui/pgp/PGPKeyListActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/pgp/PGPKeyListActivity.kt
@@ -21,14 +21,19 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import app.passwordstore.R
+import app.passwordstore.crypto.PGPKeyManager
 import app.passwordstore.ui.APSAppBar
 import app.passwordstore.ui.compose.theme.APSTheme
 import app.passwordstore.util.viewmodel.PGPKeyListViewModel
+import com.github.michaelbull.result.unwrap
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+import kotlinx.coroutines.runBlocking
 
 @AndroidEntryPoint
 class PGPKeyListActivity : ComponentActivity() {
 
+  @Inject lateinit var pgpKeyManager: PGPKeyManager
   private val viewModel: PGPKeyListViewModel by viewModels()
   private val keyImportAction =
     registerForActivityResult(StartActivityForResult()) {
@@ -71,8 +76,12 @@ class PGPKeyListActivity : ComponentActivity() {
             onKeySelected =
               if (isSelecting) {
                 { identifier ->
+                  val keyId = runBlocking {
+                    val key = pgpKeyManager.getKeyById(identifier).unwrap()
+                    pgpKeyManager.getKeyId(key) ?: throw NullPointerException()
+                  }
                   val result = Intent()
-                  result.putExtra(EXTRA_SELECTED_KEY, identifier.toString())
+                  result.putExtra(EXTRA_SELECTED_KEY, keyId.toString())
                   setResult(RESULT_OK, result)
                   finish()
                 }

--- a/app/src/main/res/layout/activity_proxy_selector.xml
+++ b/app/src/main/res/layout/activity_proxy_selector.xml
@@ -89,6 +89,8 @@
       android:id="@+id/proxy_password"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:importantForAutofill="no"
+      android:imeOptions="flagNoPersonalizedLearning"
       android:inputType="textPassword" />
   </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/layout/dialog_password_entry.xml
+++ b/app/src/main/res/layout/dialog_password_entry.xml
@@ -16,13 +16,14 @@
     android:layout_height="wrap_content"
     android:hint="@string/pgp_passphrase_input"
     app:endIconMode="password_toggle"
-    app:hintAnimationEnabled="true"
     app:hintEnabled="true">
 
     <com.google.android.material.textfield.TextInputEditText
       android:id="@+id/password_edit_text"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:importantForAutofill="no"
+      android:imeOptions="flagNoPersonalizedLearning"
       android:inputType="textPassword" />
     <requestFocus />
   </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/layout/folder_dialog_fragment.xml
+++ b/app/src/main/res/layout/folder_dialog_fragment.xml
@@ -3,20 +3,19 @@
   ~ SPDX-License-Identifier: GPL-3.0-only
   -->
 
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
-  android:layout_height="match_parent"
+  android:layout_height="wrap_content"
   android:orientation="vertical"
-  android:padding="16dp">
+  android:padding="@dimen/activity_horizontal_margin">
 
   <com.google.android.material.textfield.TextInputLayout
     android:id="@+id/folder_name_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:hint="@string/crypto_name_hint"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent">
+    app:hintEnabled="true">
 
     <com.google.android.material.textfield.TextInputEditText
       android:id="@+id/folder_name_text"
@@ -26,13 +25,9 @@
     <requestFocus />
   </com.google.android.material.textfield.TextInputLayout>
 
-  <!-- TODO(msfjarvis): Restore this functionality -->
   <com.google.android.material.checkbox.MaterialCheckBox
     android:id="@+id/set_gpg_key"
-    android:layout_width="0dp"
-    android:visibility="gone"
-    android:layout_height="wrap_content"
+    android:layout_width="match_parent"
     android:text="@string/new_folder_set_gpg_key"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/folder_name_container" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+    android:layout_height="wrap_content" />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_manual_otp_entry.xml
+++ b/app/src/main/res/layout/fragment_manual_otp_entry.xml
@@ -25,6 +25,8 @@
       android:id="@+id/secret"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
+      android:importantForAutofill="no"
+      android:imeOptions="flagNoPersonalizedLearning"
       android:inputType="textPassword" />
 
     <requestFocus />

--- a/app/src/main/res/layout/git_credential_layout.xml
+++ b/app/src/main/res/layout/git_credential_layout.xml
@@ -25,6 +25,8 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:hint="@string/ssh_keygen_passphrase"
+      android:importantForAutofill="no"
+      android:imeOptions="flagNoPersonalizedLearning"
       android:inputType="textPassword" />
 
     <requestFocus />


### PR DESCRIPTION
* allow setting a subdirectory PGP key when creating folders (restored feature from [1.11.0])
* added flags for password entry fields as an additional measure against personalised learning (may fix #138)