### PR TITLE
added feature: repo import from external folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 -   Allow setting a subdirectory PGP key when creating folders (restored feature from [1.11.0])
+-   External repository import. An external "pass" repository or a repository previously exported from the app can now be imported via Settings --> Repository --> Import repository.
 
 ### Fixed
 

--- a/app/src/main/java/app/passwordstore/data/repo/PasswordRepository.kt
+++ b/app/src/main/java/app/passwordstore/data/repo/PasswordRepository.kt
@@ -133,6 +133,17 @@ object PasswordRepository {
     return repository
   }
 
+  fun isEmpty(): Boolean {
+    val dir = getRepositoryDirectory()
+    if (
+      !dir.exists() ||
+        requireNotNull(dir.listFiles()) { "Failed to list files in ${dir.path}" }.isEmpty()
+    ) {
+      return true
+    }
+    return false
+  }
+
   /** Get the currently checked out branch. */
   fun getCurrentBranch(): String? {
     val repository = repository ?: return null

--- a/app/src/main/java/app/passwordstore/ui/settings/MiscSettings.kt
+++ b/app/src/main/java/app/passwordstore/ui/settings/MiscSettings.kt
@@ -5,61 +5,17 @@
 
 package app.passwordstore.ui.settings
 
-import android.content.Context
-import android.content.Intent
-import android.net.Uri
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.documentfile.provider.DocumentFile
 import androidx.fragment.app.FragmentActivity
 import app.passwordstore.BuildConfig
 import app.passwordstore.R
-import app.passwordstore.util.services.PasswordExportService
 import app.passwordstore.util.settings.PreferenceKeys
 import de.Maxr1998.modernpreferences.PreferenceScreen
-import de.Maxr1998.modernpreferences.helpers.onClick
-import de.Maxr1998.modernpreferences.helpers.pref
 import de.Maxr1998.modernpreferences.helpers.switch
 
-class MiscSettings(activity: FragmentActivity) : SettingsProvider {
-
-  private val storeExportAction =
-    activity.registerForActivityResult(
-      object : ActivityResultContracts.OpenDocumentTree() {
-        override fun createIntent(context: Context, input: Uri?): Intent {
-          return super.createIntent(context, input).apply {
-            flags =
-              Intent.FLAG_GRANT_READ_URI_PERMISSION or
-                Intent.FLAG_GRANT_WRITE_URI_PERMISSION or
-                Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION or
-                Intent.FLAG_GRANT_PREFIX_URI_PERMISSION
-          }
-        }
-      }
-    ) { uri: Uri? ->
-      if (uri == null) return@registerForActivityResult
-      val targetDirectory = DocumentFile.fromTreeUri(activity.applicationContext, uri)
-
-      if (targetDirectory != null) {
-        val service =
-          Intent(activity.applicationContext, PasswordExportService::class.java).apply {
-            action = PasswordExportService.ACTION_EXPORT_PASSWORD
-            putExtra("uri", uri)
-          }
-
-        activity.startForegroundService(service)
-      }
-    }
+class MiscSettings(private val activity: FragmentActivity) : SettingsProvider {
 
   override fun provideSettings(builder: PreferenceScreen.Builder) {
     builder.apply {
-      pref(PreferenceKeys.EXPORT_PASSWORDS) {
-        titleRes = R.string.prefs_export_passwords_title
-        summaryRes = R.string.prefs_export_passwords_summary
-        onClick {
-          storeExportAction.launch(null)
-          true
-        }
-      }
       switch(PreferenceKeys.CLEAR_CLIPBOARD_HISTORY) {
         defaultValue = false
         titleRes = R.string.pref_clear_clipboard_title

--- a/app/src/main/java/app/passwordstore/ui/settings/RepositorySettings.kt
+++ b/app/src/main/java/app/passwordstore/ui/settings/RepositorySettings.kt
@@ -5,11 +5,15 @@
 
 package app.passwordstore.ui.settings
 
+import android.content.Context
 import android.content.Intent
 import android.content.pm.ShortcutManager
+import android.net.Uri
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.core.content.edit
 import androidx.core.content.getSystemService
+import androidx.documentfile.provider.DocumentFile
 import androidx.fragment.app.FragmentActivity
 import app.passwordstore.R
 import app.passwordstore.data.repo.PasswordRepository
@@ -25,6 +29,7 @@ import app.passwordstore.util.extensions.sharedPrefs
 import app.passwordstore.util.extensions.snackbar
 import app.passwordstore.util.extensions.unsafeLazy
 import app.passwordstore.util.git.sshj.SshKey
+import app.passwordstore.util.services.PasswordExportService
 import app.passwordstore.util.settings.GitSettings
 import app.passwordstore.util.settings.PreferenceKeys
 import com.github.michaelbull.result.onFailure
@@ -53,6 +58,58 @@ class RepositorySettings(private val activity: FragmentActivity) : SettingsProvi
       RepositorySettingsEntryPoint::class.java,
     )
   }
+
+  private val storeExportAction =
+    activity.registerForActivityResult(
+      object : ActivityResultContracts.OpenDocumentTree() {
+        override fun createIntent(context: Context, input: Uri?): Intent {
+          return super.createIntent(context, input).apply {
+            flags =
+              Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                Intent.FLAG_GRANT_WRITE_URI_PERMISSION or
+                Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION or
+                Intent.FLAG_GRANT_PREFIX_URI_PERMISSION
+          }
+        }
+      }
+    ) { uri: Uri? ->
+      if (uri == null) return@registerForActivityResult
+      val targetDirectory = DocumentFile.fromTreeUri(activity.applicationContext, uri)
+
+      if (targetDirectory != null) {
+        val service =
+          Intent(activity.applicationContext, PasswordExportService::class.java).apply {
+            action = PasswordExportService.ACTION_EXPORT_PASSWORD
+            putExtra("uri", uri)
+          }
+
+        activity.startForegroundService(service)
+      }
+    }
+
+  private val storeImportAction =
+    activity.registerForActivityResult(
+      object : ActivityResultContracts.OpenDocumentTree() {
+        override fun createIntent(context: Context, input: Uri?): Intent {
+          return super.createIntent(context, input).apply {
+            flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
+          }
+        }
+      }
+    ) { uri: Uri? ->
+      if (uri == null) return@registerForActivityResult
+      val sourceDirectory = DocumentFile.fromTreeUri(activity.applicationContext, uri)
+
+      if (sourceDirectory != null) {
+        val service =
+          Intent(activity.applicationContext, PasswordExportService::class.java).apply {
+            action = PasswordExportService.ACTION_IMPORT_PASSWORD
+            putExtra("uri", uri)
+          }
+
+        activity.startForegroundService(service)
+      }
+    }
 
   private var showSshKeyPref: Preference? = null
 
@@ -122,6 +179,33 @@ class RepositorySettings(private val activity: FragmentActivity) : SettingsProvi
           activity.sharedPrefs.edit { putString(PreferenceKeys.SSH_OPENKEYSTORE_KEYID, null) }
           visible = false
           true
+        }
+      }
+      pref(PreferenceKeys.EXPORT_PASSWORDS) {
+        titleRes = R.string.prefs_export_passwords_title
+        summaryRes = R.string.prefs_export_passwords_summary
+        onClick {
+          storeExportAction.launch(null)
+          true
+        }
+      }
+      pref(PreferenceKeys.IMPORT_PASSWORDS) {
+        titleRes = R.string.prefs_import_passwords_title
+        summaryRes = R.string.prefs_import_passwords_summary
+        onClick {
+          if (PasswordRepository.isEmpty()) {
+            storeImportAction.launch(null)
+            true
+          } else {
+            MaterialAlertDialogBuilder(activity)
+              .setTitle(activity.getString(R.string.prefs_repo_not_empty_dialog_title))
+              .setMessage(activity.getString(R.string.prefs_repo_not_empty_dialog_summary))
+              .setPositiveButton(activity.getString(R.string.dialog_ok)) { dialog, _ ->
+                dialog.dismiss()
+              }
+              .show()
+            false
+          }
         }
       }
       pref(PreferenceKeys.GIT_DELETE_REPO) {

--- a/app/src/main/java/app/passwordstore/util/services/PasswordExportService.kt
+++ b/app/src/main/java/app/passwordstore/util/services/PasswordExportService.kt
@@ -17,6 +17,13 @@ import androidx.core.content.getSystemService
 import androidx.documentfile.provider.DocumentFile
 import app.passwordstore.R
 import app.passwordstore.data.repo.PasswordRepository
+import java.io.IOException
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import logcat.logcat
@@ -33,7 +40,46 @@ class PasswordExportService : Service() {
 
             if (targetDirectory != null) {
               createNotification()
-              exportPasswords(targetDirectory)
+
+              val repositoryDirectory =
+                requireNotNull(PasswordRepository.getRepositoryDirectory()) {
+                  "Password directory must be set to export them"
+                }
+              val sourcePassDir = DocumentFile.fromFile(repositoryDirectory)
+              logcat { "Copying ${repositoryDirectory.path} to $targetDirectory" }
+
+              val dateString = LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)
+              val passDir = targetDirectory.createDirectory("password_store_$dateString")
+
+              if (passDir != null) {
+                copyDirToDir(sourcePassDir, passDir)
+              }
+
+              stopSelf()
+              return START_NOT_STICKY
+            }
+          }
+        }
+        ACTION_IMPORT_PASSWORD -> {
+          val uri = IntentCompat.getParcelableExtra(intent, "uri", Uri::class.java)
+          if (uri != null) {
+            val externalDirectory = DocumentFile.fromTreeUri(applicationContext, uri)
+
+            if (externalDirectory != null) {
+              val repositoryDirectory =
+                requireNotNull(PasswordRepository.getRepositoryDirectory()) {
+                  "Password directory must be set to export them"
+                }
+              if (!repositoryDirectory.exists()) repositoryDirectory.mkdirs()
+              val internalRepository = DocumentFile.fromFile(repositoryDirectory)
+              logcat { "Copying $externalDirectory to ${repositoryDirectory.path}" }
+
+              copyDirToDir(externalDirectory, internalRepository)
+              /* When importing an external repo, the .bin extension is appended to the
+              files copied; we walk through the internal repo directory once more
+              and remove the .bin ending from all files we find. */
+              renameFilesInDirectoryTree(repositoryDirectory.getAbsolutePath(), ".bin", "")
+
               stopSelf()
               return START_NOT_STICKY
             }
@@ -46,31 +92,6 @@ class PasswordExportService : Service() {
 
   override fun onBind(intent: Intent?): IBinder? {
     return null
-  }
-
-  /**
-   * Exports passwords to the given directory.
-   *
-   * Recursively copies the existing password store to an external directory.
-   *
-   * @param targetDirectory directory to copy password directory to.
-   */
-  private fun exportPasswords(targetDirectory: DocumentFile) {
-
-    val repositoryDirectory =
-      requireNotNull(PasswordRepository.getRepositoryDirectory()) {
-        "Password directory must be set to export them"
-      }
-    val sourcePassDir = DocumentFile.fromFile(repositoryDirectory)
-
-    logcat { "Copying ${repositoryDirectory.path} to $targetDirectory" }
-
-    val dateString = LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)
-    val passDir = targetDirectory.createDirectory("password_store_$dateString")
-
-    if (passDir != null) {
-      copyDirToDir(sourcePassDir, passDir)
-    }
   }
 
   /**
@@ -113,6 +134,35 @@ class PasswordExportService : Service() {
     }
   }
 
+  private fun renameFilesInDirectoryTree(
+    rootDir: String,
+    oldExtension: String,
+    newExtension: String,
+  ) {
+    val startPath = Paths.get(rootDir)
+    Files.walkFileTree(
+      startPath,
+      object : SimpleFileVisitor<Path>() {
+        override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
+          val fileName = file.fileName.toString()
+          if (fileName.endsWith(oldExtension)) {
+            val newFileName = fileName.replace(oldExtension, newExtension)
+            val newFile = file.resolveSibling(newFileName)
+            Files.move(file, newFile)
+            logcat { "Renamed: $file to $newFile" }
+          }
+          return FileVisitResult.CONTINUE
+        }
+
+        override fun visitFileFailed(file: Path, exc: IOException): FileVisitResult {
+          logcat { "Failed to access file: $file" }
+          exc.printStackTrace()
+          return FileVisitResult.CONTINUE
+        }
+      },
+    )
+  }
+
   private fun createNotification() {
     createNotificationChannel()
 
@@ -145,6 +195,7 @@ class PasswordExportService : Service() {
   companion object {
 
     const val ACTION_EXPORT_PASSWORD = "ACTION_EXPORT_PASSWORD"
+    const val ACTION_IMPORT_PASSWORD = "ACTION_IMPORT_PASSWORD"
     private const val CHANNEL_ID = "NotificationService"
   }
 }

--- a/app/src/main/java/app/passwordstore/util/settings/PreferenceKeys.kt
+++ b/app/src/main/java/app/passwordstore/util/settings/PreferenceKeys.kt
@@ -22,6 +22,7 @@ object PreferenceKeys {
   const val COPY_ON_DECRYPT = "copy_on_decrypt"
   const val ENABLE_DEBUG_LOGGING = "enable_debug_logging"
   const val EXPORT_PASSWORDS = "export_passwords"
+  const val IMPORT_PASSWORDS = "import_passwords"
   const val FILTER_RECURSIVELY = "filter_recursively"
   const val GENERAL_SHOW_TIME = "general_show_time"
   const val GIT_CONFIG = "git_config"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -127,7 +127,11 @@
   <string name="pref_clear_clipboard_summary">Auf Geräten mit Zwischenablagenverlauf diesen mit Zufallszahlen überschreiben, um ggf. bestehende Passwörter zu entfernen</string>
   <string name="pref_git_delete_repo_summary">Lösche das lokale (versteckte) Repository.</string>
   <string name="prefs_export_passwords_title">Passwörter exportieren</string>
-  <string name="prefs_export_passwords_summary">Exportiert die verschlüsselten Passwörter in ein externes Verzeichnis.</string>
+  <string name="prefs_export_passwords_summary">Exportiert das Password-Repository in ein externes Verzeichnis.</string>
+  <string name="prefs_import_passwords_title">Passwörter importieren</string>
+  <string name="prefs_import_passwords_summary">Importiert ein Password-Repository aus einem externen Verzeichnis.</string>
+  <string name="prefs_repo_not_empty_dialog_title">Lokales Repository ist nicht leer</string>
+  <string name="prefs_repo_not_empty_dialog_summary">Vor dem Importieren muss das lokale Repository zunächst gelöscht werden.</string>
   <string name="pref_rebase_on_pull_title">Rebase beim Pullen</string>
   <string name="pref_rebase_on_pull_summary">Ein Merge-Commit mit Upstream-Änderungen beim Pullen oder Synchronisieren erstellen</string>
   <string name="pref_rebase_on_pull_summary_on">Beim Pullen oder Synchronisieren Commits rebasen, die nicht im Remote-Repository vorhanden sind</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,8 +127,12 @@
   <string name="pref_clear_clipboard_title">Workaround clipboard history feature</string>
   <string name="pref_clear_clipboard_summary">Enable to flood clipboard history on devices that include such a feature with consecutive numbers, flushing out any passwords</string>
   <string name="pref_git_delete_repo_summary">Deletes local (hidden) repository</string>
-  <string name="prefs_export_passwords_title">Export passwords</string>
-  <string name="prefs_export_passwords_summary">Exports the encrypted passwords to an external directory</string>
+  <string name="prefs_export_passwords_title">Export repository</string>
+  <string name="prefs_export_passwords_summary">Exports the password repository to an external directory</string>
+  <string name="prefs_import_passwords_title">Import repository</string>
+  <string name="prefs_import_passwords_summary">Imports a password repository from an external directory</string>
+  <string name="prefs_repo_not_empty_dialog_title">Local repository not empty</string>
+  <string name="prefs_repo_not_empty_dialog_summary">The local password repository must be deleted first</string>
   <string name="pref_rebase_on_pull_title">Rebase on pull</string>
   <string name="pref_rebase_on_pull_summary">When pulling or syncing, create a merge commit with upstream changes</string>
   <string name="pref_rebase_on_pull_summary_on">When pulling or syncing, rebase commits that are not present in the remote repository</string>


### PR DESCRIPTION
An external "pass" repository or a repository previously exported from the app can now be imported via Settings --> Repository --> Import repository. Fixes #113.