### PR TITLE
refactor PGPKeyManager; fix multi-key decryption

### DIFF
--- a/app/src/main/java/app/passwordstore/data/crypto/CryptoRepository.kt
+++ b/app/src/main/java/app/passwordstore/data/crypto/CryptoRepository.kt
@@ -17,6 +17,9 @@ import app.passwordstore.util.settings.PreferenceKeys
 import com.github.michaelbull.result.filterValues
 import com.github.michaelbull.result.map
 import com.github.michaelbull.result.mapBoth
+import com.github.michaelbull.result.onSuccess
+import com.github.michaelbull.result.runCatching
+import com.github.michaelbull.result.unwrap
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import javax.inject.Inject
@@ -46,6 +49,25 @@ constructor(
     return pgpCryptoHandler.isPassphraseProtected(keys)
   }
 
+  private suspend fun findMatchingIdentifier(
+    identifiers: List<PGPIdentifier>,
+    passphrase: CharArray?,
+  ): List<PGPIdentifier> {
+    if (passphrase == null) return identifiers
+    for (identifier in identifiers) {
+      runCatching {
+          pgpCryptoHandler.passphraseIsCorrect(
+            pgpKeyManager.getKeyById(identifier).unwrap(),
+            passphrase,
+          )
+        }
+        .onSuccess {
+          return listOf(identifier)
+        }
+    }
+    return identifiers
+  }
+
   suspend fun decrypt(
     passphrase: CharArray?,
     identities: List<PGPIdentifier>,
@@ -53,7 +75,8 @@ constructor(
     out: ByteArrayOutputStream,
   ) =
     withContext(dispatcherProvider.io()) {
-      val keys = identities.map { id -> pgpKeyManager.getKeyById(id) }.filterValues()
+      val matchingIdentifier = findMatchingIdentifier(identities, passphrase)
+      val keys = matchingIdentifier.map { id -> pgpKeyManager.getKeyById(id) }.filterValues()
       val decryptionOptions = PGPDecryptOptions.Builder().build()
       pgpCryptoHandler.decrypt(keys, passphrase, message, out, decryptionOptions).map { out }
     }

--- a/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
@@ -21,7 +21,9 @@ import androidx.core.content.edit
 import androidx.fragment.app.setFragmentResultListener
 import androidx.lifecycle.lifecycleScope
 import app.passwordstore.R
+import app.passwordstore.crypto.KeyUtils.tryGetEmail
 import app.passwordstore.crypto.PGPIdentifier
+import app.passwordstore.crypto.PGPKeyManager
 import app.passwordstore.data.crypto.CryptoRepository
 import app.passwordstore.data.repo.PasswordRepository
 import app.passwordstore.injection.prefs.SettingsPreferences
@@ -35,6 +37,7 @@ import app.passwordstore.util.settings.Constants
 import app.passwordstore.util.settings.PreferenceKeys
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.runCatching
+import com.github.michaelbull.result.unwrap
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.File
@@ -70,6 +73,8 @@ open class BasePGPActivity : AppCompatActivity() {
 
   /** Caching the entered passphrase, user option */
   private var cacheEnabled = false
+
+  @Inject lateinit var pgpKeyManager: PGPKeyManager
 
   /** Action to invoke if [keyImportAction] succeeds. */
   private var onKeyImport: (() -> Unit)? = null
@@ -232,6 +237,20 @@ open class BasePGPActivity : AppCompatActivity() {
     return gpgIdentifiers
   }
 
+  private fun getEmailFromKeyId(identifier: PGPIdentifier): String? {
+    val key = runBlocking { pgpKeyManager.getKeyById(identifier).unwrap() }
+    val userId = tryGetEmail(key)
+    if (userId == null) return null
+    return PGPIdentifier.splitUserId(userId.email)
+  }
+
+  private fun getEmailsFromIdentifiers(identifiers: List<PGPIdentifier>): String? {
+    val emails = identifiers.map { getEmailFromKeyId(it) }.filter { it != null }
+    if (emails.isEmpty()) return null
+    val label = if (emails.size > 1) R.string.pgp_id_label_plural else R.string.pgp_id_label
+    return "${resources.getString(label)} ${emails.joinToString(", ")}"
+  }
+
   @Suppress("ReturnCount")
   private fun File.findTillRoot(fileName: String, rootPath: File): File? {
     val gpgFile = File(this, fileName)
@@ -277,7 +296,8 @@ open class BasePGPActivity : AppCompatActivity() {
 
     val dialog =
       PasswordDialog.newInstance(
-        cacheEnabled = settings.getBoolean(PreferenceKeys.CACHE_PASSPHRASE, false)
+        cacheEnabled = settings.getBoolean(PreferenceKeys.CACHE_PASSPHRASE, false),
+        getEmailsFromIdentifiers(identifiers),
       )
     if (isError && retries > 1) {
       dialog.setError()

--- a/app/src/main/java/app/passwordstore/ui/crypto/PasswordDialog.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/PasswordDialog.kt
@@ -9,6 +9,7 @@ import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
 import android.view.KeyEvent
+import android.view.View
 import android.view.WindowManager
 import androidx.core.os.bundleOf
 import androidx.core.widget.doOnTextChanged
@@ -26,11 +27,18 @@ class PasswordDialog : DialogFragment() {
   private val binding by unsafeLazy { DialogPasswordEntryBinding.inflate(layoutInflater) }
   private var isError: Boolean = false
   private var cacheEnabledChecked: Boolean = false
+  private var userIds: String? = null
 
   override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
     val builder = MaterialAlertDialogBuilder(requireContext())
     builder.setView(binding.root)
-    builder.setTitle(R.string.pgp_passphrase_input)
+    builder.setTitle(R.string.ssh_keygen_passphrase)
+
+    userIds = requireArguments().getString(USER_IDS_EXTRA)
+    userIds?.let {
+      binding.userIdList.setText(userIds)
+      binding.userIdList.setVisibility(View.VISIBLE)
+    }
 
     cacheEnabledChecked = requireArguments().getBoolean(CACHE_ENABLED_EXTRA)
     binding.cacheEnabled.isChecked = cacheEnabledChecked
@@ -82,13 +90,14 @@ class PasswordDialog : DialogFragment() {
   companion object {
 
     private const val CACHE_ENABLED_EXTRA = "CACHE_ENABLED"
+    private const val USER_IDS_EXTRA = "USER_IDS"
 
     const val PASSWORD_RESULT_KEY = "password_result"
     const val PASSWORD_PHRASE_KEY = "password_phrase"
     const val PASSWORD_CACHE_KEY = "password_cache"
 
-    fun newInstance(cacheEnabled: Boolean): PasswordDialog {
-      val extras = bundleOf(CACHE_ENABLED_EXTRA to cacheEnabled)
+    fun newInstance(cacheEnabled: Boolean, userIds: String? = null): PasswordDialog {
+      val extras = bundleOf(CACHE_ENABLED_EXTRA to cacheEnabled, USER_IDS_EXTRA to userIds)
       val fragment = PasswordDialog()
       fragment.arguments = extras
       return fragment

--- a/app/src/main/java/app/passwordstore/ui/settings/RepositorySettings.kt
+++ b/app/src/main/java/app/passwordstore/ui/settings/RepositorySettings.kt
@@ -92,7 +92,11 @@ class RepositorySettings(private val activity: FragmentActivity) : SettingsProvi
       object : ActivityResultContracts.OpenDocumentTree() {
         override fun createIntent(context: Context, input: Uri?): Intent {
           return super.createIntent(context, input).apply {
-            flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
+            flags =
+              Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                Intent.FLAG_GRANT_WRITE_URI_PERMISSION or
+                Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION or
+                Intent.FLAG_GRANT_PREFIX_URI_PERMISSION
           }
         }
       }
@@ -100,13 +104,13 @@ class RepositorySettings(private val activity: FragmentActivity) : SettingsProvi
       if (uri == null) return@registerForActivityResult
       val sourceDirectory = DocumentFile.fromTreeUri(activity.applicationContext, uri)
 
-      if (sourceDirectory != null) {
+      // Minimal check to see if the source directory is a git repo
+      if (sourceDirectory?.findFile(".git")?.isDirectory() ?: false) {
         val service =
           Intent(activity.applicationContext, PasswordExportService::class.java).apply {
             action = PasswordExportService.ACTION_IMPORT_PASSWORD
             putExtra("uri", uri)
           }
-
         activity.startForegroundService(service)
       }
     }

--- a/app/src/main/java/app/passwordstore/util/services/PasswordExportService.kt
+++ b/app/src/main/java/app/passwordstore/util/services/PasswordExportService.kt
@@ -55,7 +55,7 @@ class PasswordExportService : Service() {
                 copyDirToDir(sourcePassDir, passDir)
               }
 
-              stopSelf()
+              stopForeground(Service.STOP_FOREGROUND_DETACH)
               return START_NOT_STICKY
             }
           }
@@ -75,12 +75,14 @@ class PasswordExportService : Service() {
               logcat { "Copying $externalDirectory to ${repositoryDirectory.path}" }
 
               copyDirToDir(externalDirectory, internalRepository)
-              /* When importing an external repo, the .bin extension is appended to the
-              files copied; we walk through the internal repo directory once more
-              and remove the .bin ending from all files we find. */
+              /**
+               * When importing an external repo, the .bin extension is appended to the files
+               * copied; we walk through the internal repo directory once more and remove the .bin
+               * ending from all files we find.
+               */
               renameFilesInDirectoryTree(repositoryDirectory.getAbsolutePath(), ".bin", "")
 
-              stopSelf()
+              stopForeground(Service.STOP_FOREGROUND_DETACH)
               return START_NOT_STICKY
             }
           }
@@ -124,7 +126,7 @@ class PasswordExportService : Service() {
    */
   private fun copyDirToDir(sourceDirectory: DocumentFile, targetDirectory: DocumentFile) {
     sourceDirectory.listFiles().forEach { file ->
-      if (file.isDirectory) {
+      if (file.isDirectory()) {
         // Create new directory and recurse
         val newDir = targetDirectory.createDirectory(file.name ?: throw NullPointerException())
         copyDirToDir(file, newDir ?: throw NullPointerException())

--- a/app/src/main/res/layout/dialog_password_entry.xml
+++ b/app/src/main/res/layout/dialog_password_entry.xml
@@ -10,11 +10,18 @@
   android:orientation="vertical"
   android:padding="@dimen/activity_horizontal_margin">
 
+  <TextView
+   android:id="@+id/user_id_list"
+   android:layout_marginBottom="@dimen/normal_margin"
+   android:visibility="gone"
+   android:layout_width="match_parent"
+   android:layout_height="wrap_content" />
+
   <com.google.android.material.textfield.TextInputLayout
     android:id="@+id/password_field"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:hint="@string/pgp_passphrase_input"
+    android:hint="@string/ssh_keygen_passphrase"
     app:endIconMode="password_toggle"
     app:hintEnabled="true">
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -161,7 +161,7 @@
   <string name="pref_password_generator_type_title">Passwortgenerator</string>
 
   <!-- ssh keygen fragment -->
-  <string name="ssh_keygen_passphrase">Passwort</string>
+  <string name="ssh_keygen_passphrase">Kennwortsatz</string>
   <string name="ssh_keygen_generate">Erstellen</string>
   <string name="ssh_keygen_share">Teilen</string>
   <string name="ssh_keygen_later">Später</string>
@@ -277,7 +277,7 @@
   <string name="git_server_config_save_missing_username_https">Bitte geben Sie den HTTPS-Benutzernamen in der Form https://username@example.com/… an.</string>
   <string name="git_server_config_save_missing_username_ssh">Bitte geben Sie den SSH-Benutzernamen in der Form username@example.com:… an.</string>
   <string name="git_server_config_save_auth_mode_mismatch">Gültige Authentifizierungsarten für %1$s: %2$s</string>
-  <string name="git_operation_wrong_passphrase">Falsches Kennwort</string>
+  <string name="git_operation_wrong_passphrase">Falscher Kennwortsatz</string>
   <string name="git_operation_wrong_password">Falsches Passwort</string>
   <string name="bottom_sheet_create_new_folder">Neuen Ordner erstellen</string>
   <string name="bottom_sheet_create_new_password">Neues Passwort erstellen</string>
@@ -376,7 +376,8 @@
   <string name="no_keys_imported_dialog_message">Es wurden noch keine PGP-Schlüssel in die App importiert. Wählen Sie eine Schlüsseldatei über die Schaltfläche \"Importieren\" aus.</string>
 
   <!-- Passphrase input -->
-  <string name="cache_password_until_screen_off">Passphrase bis zum Abschalten des Bildschirms merken</string>
-  <string name="pgp_passphrase_input">PGP-Passphrase</string>
-  <string name="pgp_wrong_passphrase_input">Falsche PGP-Passphrase</string>
+  <string name="cache_password_until_screen_off">Kennwortsatz bis zum Abschalten des Bildschirms merken</string>
+  <string name="pgp_wrong_passphrase_input">Falsche Eingabe</string>
+  <string name="pgp_id_label">PGP-ID:</string>
+  <string name="pgp_id_label_plural">PGP-IDs:</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -129,7 +129,7 @@
   <!-- Password generator prefs -->
   <string name="pref_password_generator_type_title">Type de générateur de mot de passe</string>
   <!-- ssh keygen fragment -->
-  <string name="ssh_keygen_passphrase">Mot de passe</string>
+  <string name="ssh_keygen_passphrase">Phrase de passe</string>
   <string name="ssh_keygen_generate">Générer</string>
   <string name="ssh_keygen_share">Partager</string>
   <string name="ssh_keygen_later">Plus tard</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -378,6 +378,7 @@
 
   <!-- Passphrase input -->
   <string name="cache_password_until_screen_off">Keep passphrase until screen-off</string>
-  <string name="pgp_passphrase_input">PGP passphrase</string>
-  <string name="pgp_wrong_passphrase_input">wrong PGP passphrase</string>
+  <string name="pgp_wrong_passphrase_input">Wrong passphrase</string>
+  <string name="pgp_id_label">PGP ID: </string>
+  <string name="pgp_id_label_plural">PGP IDs: </string>
 </resources>

--- a/crypto/common/src/main/kotlin/app/passwordstore/crypto/CryptoHandler.kt
+++ b/crypto/common/src/main/kotlin/app/passwordstore/crypto/CryptoHandler.kt
@@ -13,6 +13,8 @@ import java.io.OutputStream
 /** Generic interface to implement cryptographic operations on top of. */
 public interface CryptoHandler<Key, EncOpts : CryptoOptions, DecryptOpts : CryptoOptions> {
 
+  public fun passphraseIsCorrect(key: Key, passphrase: CharArray): Boolean
+
   /**
    * Decrypt the given [ciphertextStream] using a set of potential [keys] and [passphrase], and
    * writes the resultant plaintext to [outputStream]. The returned [Result] should be checked to

--- a/crypto/pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPKeyManager.kt
+++ b/crypto/pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPKeyManager.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.withContext
 import org.bouncycastle.openpgp.PGPPublicKeyRing
 import org.bouncycastle.openpgp.PGPSecretKeyRing
 import org.pgpainless.PGPainless
+import org.pgpainless.key.util.KeyRingUtils
 
 public class PGPKeyManager
 @Inject
@@ -95,32 +96,32 @@ constructor(filesDir: String, private val dispatcher: CoroutineDispatcher) :
         if (keyFiles.isNullOrEmpty()) throw NoKeysAvailableException
         val keys = keyFiles.map { file -> PGPKey(file.readBytes()) }
 
-        val matchResult =
-          when (id) {
-            is PGPIdentifier.KeyId -> {
-              val keyIdMatch =
-                keys
-                  .map { key -> key to tryGetId(key) }
-                  .firstOrNull { (_, keyId) -> keyId?.id == id.id }
-              keyIdMatch?.first
-            }
-            is PGPIdentifier.UserId -> {
-              val userIdMatch =
-                keys
-                  .map { key -> key to tryParseKeyring(key) }
-                  .firstOrNull { (_, keyring) ->
-                    keyring?.let {
-                      PGPainless.inspectKeyRing(keyring).userIds.any {
-                        id.email == it || id.email == PGPIdentifier.splitUserId(it)
-                      }
-                    } ?: false
-                  }
-              userIdMatch?.first
+        when (id) {
+          is PGPIdentifier.KeyId -> {
+            for (key in keys) {
+              val keyRing = tryParseKeyring(key) ?: continue
+              if (
+                KeyRingUtils.keyRingContainsKeyWithId(
+                  KeyRingUtils.publicKeys(keyRing),
+                  id.id.toLong(),
+                )
+              ) {
+                return@runSuspendCatching key
+              }
             }
           }
-
-        if (matchResult != null) {
-          return@runSuspendCatching matchResult
+          is PGPIdentifier.UserId -> {
+            for (key in keys) {
+              val keyRing = tryParseKeyring(key) ?: continue
+              if (
+                PGPainless.inspectKeyRing(keyRing).userIds.any {
+                  id.email == it || id.email == PGPIdentifier.splitUserId(it)
+                }
+              ) {
+                return@runSuspendCatching key
+              }
+            }
+          }
         }
 
         throw KeyNotFoundException("$id")

--- a/crypto/pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPainlessCryptoHandler.kt
+++ b/crypto/pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPainlessCryptoHandler.kt
@@ -16,6 +16,7 @@ import com.github.michaelbull.result.runCatching
 import java.io.InputStream
 import java.io.OutputStream
 import javax.inject.Inject
+import org.bouncycastle.openpgp.PGPPrivateKey
 import org.bouncycastle.openpgp.PGPPublicKeyRing
 import org.bouncycastle.openpgp.PGPPublicKeyRingCollection
 import org.bouncycastle.openpgp.PGPSecretKeyRing
@@ -27,10 +28,18 @@ import org.pgpainless.encryption_signing.EncryptionOptions
 import org.pgpainless.encryption_signing.ProducerOptions
 import org.pgpainless.exception.WrongPassphraseException
 import org.pgpainless.key.protection.SecretKeyRingProtector
+import org.pgpainless.key.protection.UnlockSecretKey
 import org.pgpainless.util.Passphrase
 
 public class PGPainlessCryptoHandler @Inject constructor() :
   CryptoHandler<PGPKey, PGPEncryptOptions, PGPDecryptOptions> {
+
+  public override fun passphraseIsCorrect(key: PGPKey, passphrase: CharArray): Boolean {
+    val secretKey =
+      PGPainless.readKeyRing().secretKeyRing(key.contents)?.getSecretKey() ?: return false
+    val protector = SecretKeyRingProtector.unlockAnyKeyWith(Passphrase(passphrase))
+    return (UnlockSecretKey.unlockSecretKey(secretKey, protector) as? PGPPrivateKey) != null
+  }
 
   /**
    * Decrypts the given [ciphertextStream] using [PGPainless] and writes the decrypted output to


### PR DESCRIPTION
* retrieve correct PGP key based user ID and key ID including sub-key ID
* display user ID / user IDs (in case of multi-key enrypted entries) on the passphrase input dialog
* in case of multi-key encrypted password entries, verify entered passphrase against all key IDs found in the .gpg-id