### PR TITLE
adding new store entries in autofill mode fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ All notable changes to this project will be documented in this file.
 -   Auto-dismiss an abandoned password edit dialog after configurable timeout (password copy timeout is used if configured, 60 seconds otherwise) to prevent information leakage
 -   Initialising an empty cloned non-pass repo is now possible. The repo to be cloned should however already have at least one commit, e. g. an added and removed dummy file
 -   Fix app crashes due to a `.gpg-id` file containing an invalid or unknown key/user ID. Prompt for re-selecting/re-importing a PGP secret key file
--   In case of multi-key encrypted store entries, decryption failed with passphrases for the other PGP IDs in the `.gpg-id` file that appear below the first entry
+-   In case of multi-key encrypted store entries, decryption failed with passphrases for the other PGP IDs that appear below the first entry in the `.gpg-id` file
 -   The PGP key is now retrieved also for subkey IDs listed in the `.gpg-id` file
+-   Fail to save a new store entry in autofill mode
 
 ### Changed
 

--- a/app/src/main/java/app/passwordstore/ui/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/PasswordCreationActivity.kt
@@ -448,7 +448,9 @@ class PasswordCreationActivity : BasePGPActivity() {
                 oldName != editName
             ) {
               val oldPath = Paths.get(repoPath, oldCategory?.trim('/') ?: "", "$oldName.gpg")
-              if (!oldPath.isSameFileAs(passwordFile) && !oldPath.deleteIfExists()) {
+              if (
+                oldPath.exists() && !oldPath.isSameFileAs(passwordFile) && !oldPath.deleteIfExists()
+              ) {
                 setResult(RESULT_CANCELED)
                 MaterialAlertDialogBuilder(this@PasswordCreationActivity)
                   .setTitle(R.string.password_creation_file_fail_title)


### PR DESCRIPTION
New password entries were not committed to the git repo when created in autofill mode. Fixes #154