### PR TITLE
avoid assigning decrypted passwords to String vars

### DIFF
--- a/app/src/main/java/app/passwordstore/data/password/FieldItem.kt
+++ b/app/src/main/java/app/passwordstore/data/password/FieldItem.kt
@@ -11,7 +11,7 @@ class FieldItem
 private constructor(
   val type: ItemType,
   val label: String,
-  val value: String,
+  val value: CharArray,
   val action: ActionType,
 ) {
   enum class ActionType {
@@ -31,21 +31,21 @@ private constructor(
       return FieldItem(
         ItemType.OTP,
         label.format(totp.remainingTime.inWholeSeconds),
-        totp.value,
+        totp.value.toCharArray(),
         ActionType.COPY,
       )
     }
 
-    fun createPasswordField(label: String, password: String): FieldItem {
+    fun createPasswordField(label: String, password: CharArray): FieldItem {
       return FieldItem(ItemType.PASSWORD, label, password, ActionType.HIDE)
     }
 
     fun createUsernameField(label: String, username: String): FieldItem {
-      return FieldItem(ItemType.USERNAME, label, username, ActionType.COPY)
+      return FieldItem(ItemType.USERNAME, label, username.toCharArray(), ActionType.COPY)
     }
 
     fun createFreeformField(label: String, content: String): FieldItem {
-      return FieldItem(ItemType.FREEFORM, label, content, ActionType.COPY)
+      return FieldItem(ItemType.FREEFORM, label, content.toCharArray(), ActionType.COPY)
     }
   }
 }

--- a/app/src/main/java/app/passwordstore/ui/adapters/FieldItemAdapter.kt
+++ b/app/src/main/java/app/passwordstore/ui/adapters/FieldItemAdapter.kt
@@ -60,7 +60,7 @@ class FieldItemAdapter(
       with(binding) {
         itemText.hint = fieldItem.label
         itemTextContainer.hint = fieldItem.label
-        itemText.setText(fieldItem.value)
+        itemText.setText(String(fieldItem.value))
 
         when (fieldItem.action) {
           FieldItem.ActionType.COPY -> {

--- a/app/src/main/java/app/passwordstore/ui/autofill/AutofillSaveActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/autofill/AutofillSaveActivity.kt
@@ -126,7 +126,7 @@ class AutofillSaveActivity : AppCompatActivity() {
         if (result.resultCode == RESULT_OK && data != null) {
           val createdPath = data.getStringExtra("CREATED_FILE") ?: throw NullPointerException()
           formOrigin?.let { AutofillMatcher.addMatchFor(this, it, File(createdPath)) }
-          val password = data.getStringExtra("PASSWORD")
+          val password = data.getCharArrayExtra("PASSWORD")
           val resultIntent =
             if (password != null) {
               // Password was generated and should be filled into a form.

--- a/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
@@ -108,12 +108,12 @@ open class BasePGPActivity : AppCompatActivity() {
    * [showSnackbar] as false.
    */
   fun copyTextToClipboard(
-    text: String?,
+    text: CharArray?,
     showSnackbar: Boolean = true,
     @StringRes snackbarTextRes: Int = R.string.clipboard_copied_text,
   ) {
     val clipboard = clipboard ?: return
-    val clip = ClipData.newPlainText((100000..999999).random().toString(), text)
+    val clip = ClipData.newPlainText((100000..999999).random().toString(), text?.let { String(it) })
     clip.description.extras =
       PersistableBundle().apply {
         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.S_V2)
@@ -153,7 +153,7 @@ open class BasePGPActivity : AppCompatActivity() {
    * Copies a provided [password] string to the clipboard. This wraps [copyTextToClipboard] to
    * optionally hide the default [Snackbar] and starts off a timer to clear the clipboard.
    */
-  protected fun copyPasswordToClipboard(password: String?): ScheduledExecutorService? {
+  protected fun copyPasswordToClipboard(password: CharArray?): ScheduledExecutorService? {
     copyTextToClipboard(password)
 
     val clearAfter = settings.getString(PreferenceKeys.GENERAL_SHOW_TIME)?.toIntOrNull() ?: 45

--- a/app/src/main/java/app/passwordstore/ui/crypto/DecryptActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/DecryptActivity.kt
@@ -50,7 +50,7 @@ class DecryptActivity : BasePGPActivity() {
       passwordCategory.text = relativeParentPath
       passwordFile.text = name
       passwordFile.setOnLongClickListener {
-        copyTextToClipboard(name)
+        copyTextToClipboard(name.toCharArray())
         true
       }
     }
@@ -61,7 +61,7 @@ class DecryptActivity : BasePGPActivity() {
     menuInflater.inflate(R.menu.pgp_handler, menu)
     passwordEntry?.let { entry ->
       menu.findItem(R.id.edit_password).isVisible = true
-      if (!entry.password.isNullOrBlank()) {
+      if (entry.password?.let { !String(it).isBlank() } ?: false) {
         menu.findItem(R.id.share_password_as_plaintext).isVisible = true
         menu.findItem(R.id.copy_password).isVisible = true
       }
@@ -108,7 +108,7 @@ class DecryptActivity : BasePGPActivity() {
     val sendIntent =
       Intent().apply {
         action = Intent.ACTION_SEND
-        putExtra(Intent.EXTRA_TEXT, passwordEntry?.password)
+        putExtra(Intent.EXTRA_TEXT, passwordEntry?.password?.let { String(it) })
         type = "text/plain"
       }
     // Always show a picker to give the user a chance to cancel
@@ -160,7 +160,7 @@ class DecryptActivity : BasePGPActivity() {
       invalidateOptionsMenu()
 
       val items = arrayListOf<FieldItem>()
-      if (!entry.password.isNullOrBlank()) {
+      if (entry.password?.let { !String(it).isBlank() } ?: false) {
         items.add(
           FieldItem.createPasswordField(
             getString(R.string.password),
@@ -190,7 +190,8 @@ class DecryptActivity : BasePGPActivity() {
         items.add(FieldItem.createFreeformField(key, value))
       }
 
-      val adapter = FieldItemAdapter(items, showPassword) { text -> copyTextToClipboard(text) }
+      val adapter =
+        FieldItemAdapter(items, showPassword) { text -> copyTextToClipboard(text?.toCharArray()) }
       binding.recyclerView.adapter = adapter
       binding.recyclerView.itemAnimator = null
 

--- a/app/src/main/java/app/passwordstore/ui/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/PasswordCreationActivity.kt
@@ -80,7 +80,7 @@ class PasswordCreationActivity : BasePGPActivity() {
 
   private val suggestedName by unsafeLazy { intent.getStringExtra(EXTRA_FILE_NAME) }
   private val suggestedUsername by unsafeLazy { intent.getStringExtra(EXTRA_USERNAME) }
-  private val suggestedPass by unsafeLazy { intent.getStringExtra(EXTRA_PASSWORD) }
+  private val suggestedPass by unsafeLazy { intent.getCharArrayExtra(EXTRA_PASSWORD) }
   private val suggestedExtra by unsafeLazy { intent.getStringExtra(EXTRA_EXTRA_CONTENT) }
   private val shouldGeneratePassword by unsafeLazy {
     intent.getBooleanExtra(EXTRA_GENERATE_PASSWORD, false)
@@ -249,7 +249,7 @@ class PasswordCreationActivity : BasePGPActivity() {
         }
       }
       suggestedPass?.let {
-        password.setText(it)
+        password.setText(String(it))
         password.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
       }
       suggestedExtra?.let { extraContent.setText(it) }
@@ -336,7 +336,7 @@ class PasswordCreationActivity : BasePGPActivity() {
       val oldName = suggestedName
       val editName = filename.text.toString().trim()
       var editUsername = username.text.toString()
-      val editPass = password.text.toString()
+      val editPass = password.text.toString().toCharArray()
       val editExtra = extraContent.text.toString()
 
       if (editName.isEmpty()) {
@@ -363,7 +363,6 @@ class PasswordCreationActivity : BasePGPActivity() {
 
       // pass enters the key ID into `.gpg-id`.
       val gpgIdentifiers = getPGPIdentifiers(directory.text.toString()) ?: return@with
-      val content = "$editPass$editUsername\n$editExtra"
       val path =
         when {
           // If we allowed the user to edit the relative path, we have to consider it here
@@ -394,7 +393,11 @@ class PasswordCreationActivity : BasePGPActivity() {
             val result =
               withContext(dispatcherProvider.io()) {
                 val outputStream = ByteArrayOutputStream()
-                repository.encrypt(gpgIdentifiers, content.byteInputStream(), outputStream)
+                repository.encrypt(
+                  gpgIdentifiers,
+                  "${String(editPass)}$editUsername\n$editExtra".byteInputStream(),
+                  outputStream,
+                )
                 outputStream
               }
             val passwordFile = Paths.get(path)
@@ -435,7 +438,10 @@ class PasswordCreationActivity : BasePGPActivity() {
 
             if (shouldGeneratePassword) {
               val directoryStructure = AutofillPreferences.directoryStructure(applicationContext)
-              val entry = passwordEntryFactory.create(content.encodeToByteArray())
+              val entry =
+                passwordEntryFactory.create(
+                  "${String(editPass)}$editUsername\n$editExtra".encodeToByteArray()
+                )
               returnIntent.putExtra(RETURN_EXTRA_PASSWORD, entry.password)
               val username =
                 entry.username ?: directoryStructure.getUsernameFor(passwordFile.toFile())

--- a/app/src/main/java/app/passwordstore/util/services/OreoAutofillService.kt
+++ b/app/src/main/java/app/passwordstore/util/services/OreoAutofillService.kt
@@ -135,11 +135,12 @@ class OreoAutofillService : AutofillService() {
 
     val username = scenario.usernameValue
     val password =
-      scenario.passwordValue
-        ?: run {
-          callback.onFailure(getString(R.string.oreo_autofill_save_passwords_dont_match))
-          return
-        }
+      (scenario.passwordValue
+          ?: run {
+            callback.onFailure(getString(R.string.oreo_autofill_save_passwords_dont_match))
+            return
+          })
+        .toCharArray()
     callback.onSuccess(
       AutofillSaveActivity.makeSaveIntentSender(
         this,

--- a/autofill-parser/api.txt
+++ b/autofill-parser/api.txt
@@ -54,16 +54,16 @@ package com.github.androidpasswordstore.autofillparser {
   }
 
   public final class Credentials {
-    ctor public Credentials(String? username, String? password, String? otp);
+    ctor public Credentials(String? username, char[]? password, String? otp);
     method public String? component1();
-    method public String? component2();
+    method public char[]? component2();
     method public String? component3();
-    method public com.github.androidpasswordstore.autofillparser.Credentials copy(String? username, String? password, String? otp);
+    method public com.github.androidpasswordstore.autofillparser.Credentials copy(String? username, char[]? password, String? otp);
     method public String? getOtp();
-    method public String? getPassword();
+    method public char[]? getPassword();
     method public String? getUsername();
     property public final String? otp;
-    property public final String? password;
+    property public final char[]? password;
     property public final String? username;
   }
 

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillFormParser.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillFormParser.kt
@@ -195,7 +195,7 @@ private class AutofillFormParser(
   }
 }
 
-public data class Credentials(val username: String?, val password: String?, val otp: String?)
+public data class Credentials(val username: String?, val password: CharArray?, val otp: String?)
 
 /**
  * Represents a collection of fields in a specific app that can be filled or saved. This is the

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillScenario.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/AutofillScenario.kt
@@ -250,13 +250,13 @@ public fun Dataset.Builder.fillWith(
   action: AutofillAction,
   credentials: Credentials?,
 ) {
-  val credentialsToFill = credentials ?: Credentials("USERNAME", "PASSWORD", "OTP")
+  val credentialsToFill = credentials ?: Credentials("USERNAME", "PASSWORD".toCharArray(), "OTP")
   for (field in scenario.fieldsToFillOn(action)) {
     val value =
       when (field) {
         scenario.username -> credentialsToFill.username
         scenario.otp -> credentialsToFill.otp
-        else -> credentialsToFill.password
+        else -> credentialsToFill.password?.let { String(it) }
       }
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
       setField(field, Field.Builder().setValue(AutofillValue.forText(value)).build())

--- a/format/common/src/main/kotlin/app/passwordstore/data/passfile/PasswordEntry.kt
+++ b/format/common/src/main/kotlin/app/passwordstore/data/passfile/PasswordEntry.kt
@@ -37,10 +37,8 @@ constructor(
   @Assisted bytes: ByteArray,
 ) {
 
-  private val content = bytes.decodeToString()
-
   /** The password text for this entry. Can be null. */
-  public val password: String?
+  public val password: CharArray?
 
   /** The username for this entry. Can be null. */
   public val username: String?
@@ -91,15 +89,16 @@ constructor(
   private val totpSecret: String?
 
   init {
-    val (foundPassword, passContent) = findAndStripPassword(content.split("\n".toRegex()))
+    val (foundPassword, passContent) =
+      findAndStripPassword(bytes.decodeToString().split("\n".toRegex()).map { it.toCharArray() })
     password = foundPassword
-    extraContentString = passContent.joinToString("\n")
+    extraContentString = passContent.map { String(it) }.joinToString("\n")
     extraContentWithoutUsername = generateExtraContentWithoutUsername()
     extraContentWithoutAuthData = generateExtraContentWithoutAuthData()
     extraContent = generateExtraContentPairs()
     username = findUsername()
     // Verify the TOTP secret is valid and disable TOTP if not.
-    val secret = totpFinder.findSecret(content)
+    val secret = totpFinder.findSecret(extraContentString)
     totpSecret =
       if (secret != null && calculateTotp(secret).isOk) {
         secret
@@ -113,15 +112,30 @@ constructor(
   }
 
   @Suppress("ReturnCount")
-  private fun findAndStripPassword(passContent: List<String>): Pair<String?, List<String>> {
-    if (TotpFinder.TOTP_FIELDS.any { passContent[0].startsWith(it) }) return Pair(null, passContent)
-    for (line in passContent) {
+  private fun findAndStripPassword(
+    passContent: List<CharArray>
+  ): Pair<CharArray?, List<CharArray>> {
+    var lines = passContent
+    var passwdLine: CharArray? = null
+    var prefixLength = 0
+    for (line in lines) {
       for (prefix in PASSWORD_FIELDS) {
-        if (line.startsWith(prefix, ignoreCase = true)) {
-          return Pair(line.substring(prefix.length).trimStart(), passContent.minus(line))
+        if (String(line).startsWith(prefix, ignoreCase = true)) {
+          passwdLine = line // last line with prefixed password wins
+          lines = lines.minus(line)
+          prefixLength = prefix.length
+          break
         }
       }
     }
+    passwdLine?.let {
+      return Pair(String(passwdLine).substring(prefixLength).trimStart().toCharArray(), lines)
+    }
+    // If the first line contains any of the other known prefixes, we assume that no password
+    // is present
+    if (TotpFinder.TOTP_FIELDS.plus(USERNAME_FIELDS).any { String(passContent[0]).startsWith(it) })
+      return Pair(null, passContent)
+    // Otherwise, we assume that the first line is the (un-prefixed) password
     return Pair(passContent[0], passContent.minus(passContent[0]))
   }
 
@@ -211,10 +225,10 @@ constructor(
   }
 
   private fun calculateTotp(secret: String = totpSecret!!): Result<Totp, Throwable> {
-    val digits = totpFinder.findDigits(content)
-    val totpPeriod = totpFinder.findPeriod(content)
-    val totpAlgorithm = totpFinder.findAlgorithm(content)
-    val issuer = totpFinder.findIssuer(content)
+    val digits = totpFinder.findDigits(extraContentString)
+    val totpPeriod = totpFinder.findPeriod(extraContentString)
+    val totpAlgorithm = totpFinder.findAlgorithm(extraContentString)
+    val issuer = totpFinder.findIssuer(extraContentString)
     val millis = clock.millis()
     val remainingTime = (totpPeriod - ((millis / THOUSAND_MILLIS) % totpPeriod)).seconds
     return Otp.calculateCode(

--- a/format/common/src/test/kotlin/app/passwordstore/data/passfile/PasswordEntryTest.kt
+++ b/format/common/src/test/kotlin/app/passwordstore/data/passfile/PasswordEntryTest.kt
@@ -30,19 +30,28 @@ class PasswordEntryTest {
 
   @Test
   fun getPassword() {
-    assertEquals("fooooo", makeEntry("fooooo\nbla\n").password)
-    assertEquals("fooooo", makeEntry("fooooo\nbla").password)
-    assertEquals("fooooo", makeEntry("fooooo\n").password)
-    assertEquals("fooooo", makeEntry("fooooo").password)
-    assertEquals("", makeEntry("\nblubb\n").password)
-    assertEquals("", makeEntry("\nblubb").password)
-    assertEquals("", makeEntry("\n").password)
-    assertEquals("", makeEntry("").password)
+    assertEquals("fooooo", makeEntry("fooooo\nbla\n").password?.let { String(it) })
+    assertEquals("fooooo", makeEntry("fooooo\nbla").password?.let { String(it) })
+    assertEquals("fooooo", makeEntry("fooooo\n").password?.let { String(it) })
+    assertEquals("fooooo", makeEntry("fooooo").password?.let { String(it) })
+    assertEquals("", makeEntry("\nblubb\n").password?.let { String(it) })
+    assertEquals("", makeEntry("\nblubb").password?.let { String(it) })
+    assertEquals("", makeEntry("\n").password?.let { String(it) })
+    assertEquals("", makeEntry("").password?.let { String(it) })
     for (field in PasswordEntry.PASSWORD_FIELDS) {
-      assertEquals("fooooo", makeEntry("\n$field fooooo").password)
-      assertEquals("fooooo", makeEntry("\n${field.uppercase(Locale.getDefault())} fooooo").password)
-      assertEquals("fooooo", makeEntry("GOPASS-SECRET-1.0\n$field fooooo").password)
-      assertEquals("fooooo", makeEntry("someFirstLine\nUsername: bar\n$field fooooo").password)
+      assertEquals("fooooo", makeEntry("\n$field fooooo").password?.let { String(it) })
+      assertEquals(
+        "fooooo",
+        makeEntry("\n${field.uppercase(Locale.getDefault())} fooooo").password?.let { String(it) },
+      )
+      assertEquals(
+        "fooooo",
+        makeEntry("GOPASS-SECRET-1.0\n$field fooooo").password?.let { String(it) },
+      )
+      assertEquals(
+        "fooooo",
+        makeEntry("someFirstLine\nUsername: bar\n$field fooooo").password?.let { String(it) },
+      )
     }
   }
 
@@ -158,7 +167,7 @@ class PasswordEntryTest {
   @Test
   fun generatesOtpWithOnlyUriInFile() = runTest {
     val entry = makeEntry(TOTP_URI)
-    assertNull(entry.password)
+    assertNull(entry.password?.let { String(it) })
     entry.totp.test {
       val otp = expectMostRecentItem()
       assertEquals("818800", otp.value)
@@ -188,9 +197,9 @@ class PasswordEntryTest {
   @Test
   fun onlyLooksForUriInFirstLine() {
     val entry = makeEntry("id:\n$TOTP_URI")
-    assertNotNull(entry.password)
+    assertNull(entry.password?.let { String(it) })
     assertTrue(entry.hasTotp())
-    assertNull(entry.username)
+    assertNotNull(entry.username)
   }
 
   // https://github.com/android-password-store/Android-Password-Store/issues/1190
@@ -200,7 +209,7 @@ class PasswordEntryTest {
     assertTrue(entry.extraContent.isNotEmpty())
     assertTrue(entry.hasTotp())
     assertNotNull(entry.username)
-    assertEquals("pass", entry.password)
+    assertEquals("pass", entry.password?.let { String(it) })
     assertEquals("user", entry.username)
     assertEquals(mapOf("id" to "id"), entry.extraContent)
   }


### PR DESCRIPTION
This is to prevent decrypted passwords from showing up in memory dumps and from being exposed through other malicious activities. We will use CharArray instead.

See

https://docs.oracle.com/javase/6/docs/technotes/guides/security/crypto/CryptoSpec.html#PBEEx
https://stackoverflow.com/questions/8881291/why-is-char-preferred-over-string-for-passwords