### PR TITLE
copy OTP to the clipboard on autofill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Display user ID (or user IDs in case of multi-key encrypted entries) on the passphrase input dialog
 - Allow setting a subdirectory PGP key when creating folders (restored feature from v1.11.0)
 - External repository import. An external "pass" repository or a repository previously exported from the app can now be imported via Settings --> Repository --> Import repository
+- Copy OTP to the clipboard during autofill: If the pass entry contains an OTP, it is copied to the clipboard to facilitate autofill. The OTP in the clipboard is refreshed once when the first copy expires. This is to handle the situation when the first OTP was calculated just before its expiry.
 
   [Original repo](https://github.com/android-password-store/Android-Password-Store) up to archiving:
 - On Android 11, Autofill will use the new [inline autofill](https://developer.android.com/guide/topics/text/ime-autofill#configure-provider) UI that integrates Autofill results into your keyboard app.

--- a/app/src/main/java/app/passwordstore/ui/autofill/AutofillDecryptActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/autofill/AutofillDecryptActivity.kt
@@ -26,6 +26,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlinx.coroutines.launch
@@ -107,6 +108,19 @@ class AutofillDecryptActivity : BasePGPActivity() {
           RESULT_OK,
           Intent().apply { putExtra(AutofillManager.EXTRA_AUTHENTICATION_RESULT, fillInDataset) },
         )
+        if (entry.hasTotp()) {
+          val otp = entry.currentOtp
+          val remainingTime = otp.remainingTime.inWholeSeconds
+          copyTextToClipboard(otp.value.toCharArray(), isSensitive = false)
+          otpTimer?.shutdownNow()
+          val otpTimerNew = Executors.newSingleThreadScheduledExecutor()
+          otpTimer = otpTimerNew
+          otpTimerNew.schedule( // refresh otp once
+            { copyTextToClipboard(entry.currentOtp.value.toCharArray(), isSensitive = false) },
+            remainingTime,
+            TimeUnit.SECONDS,
+          )
+        }
       }
       onSuccess()
       withContext(dispatcherProvider.main()) { finish() }
@@ -131,6 +145,7 @@ class AutofillDecryptActivity : BasePGPActivity() {
     private const val EXTRA_SEARCH_ACTION = "app.passwordstore.autofill.oreo.EXTRA_SEARCH_ACTION"
 
     private var decryptFileRequestCode = 1
+    private var otpTimer: ScheduledExecutorService? = null
 
     fun makeDecryptFileIntent(file: File, forwardedExtras: Bundle, context: Context): Intent {
       return Intent(context, AutofillDecryptActivity::class.java).apply {

--- a/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
@@ -334,6 +334,9 @@ open class BasePGPActivity : AppCompatActivity() {
     const val EXTRA_FILE_PATH = "FILE_PATH"
     const val EXTRA_REPO_PATH = "REPO_PATH"
 
+    var cachedPassphrase: CharArray? = null
+    var clearTimer: ScheduledExecutorService? = null
+
     /**
      * Newest Samsung phones now feature a history of up to 30 items. To err on the side of caution,
      * push 35 fake ones.
@@ -368,9 +371,5 @@ open class BasePGPActivity : AppCompatActivity() {
         basename
       }
     }
-
-    var cachedPassphrase: CharArray? = null
-
-    var clearTimer: ScheduledExecutorService? = null
   }
 }

--- a/app/src/main/java/app/passwordstore/util/autofill/AutofillPreferences.kt
+++ b/app/src/main/java/app/passwordstore/util/autofill/AutofillPreferences.kt
@@ -30,7 +30,7 @@ object AutofillPreferences {
     // Always give priority to a username stored in the encrypted extras
     val username =
       entry.username ?: directoryStructure.getUsernameFor(file) ?: context.getDefaultUsername()
-    val totp = if (entry.hasTotp()) entry.currentOtp else null
+    val totp = if (entry.hasTotp()) entry.currentOtp.value else null
     return Credentials(username, entry.password, totp)
   }
 }

--- a/format/common/src/main/kotlin/app/passwordstore/data/passfile/PasswordEntry.kt
+++ b/format/common/src/main/kotlin/app/passwordstore/data/passfile/PasswordEntry.kt
@@ -73,11 +73,11 @@ constructor(
   }
 
   /** Obtain the [Totp.value] for this [PasswordEntry] at the current time. */
-  public val currentOtp: String
+  public val currentOtp: Totp
     get() {
       val otp = calculateTotp()
       check(otp.isOk)
-      return otp.value.value
+      return otp.value
     }
 
   private val totpSecret: String?


### PR DESCRIPTION
If the pass entry contains an OTP, it is copied to the clipboard to facilitate autofill. The OTP in the clipboard is refreshed once when the first copy expires. This is to handle the situation when the first OTP was calculated just before its expiry.

Fixes #171