### PR TITLE
prevent disabling passphrase caching after AES key invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Emit a warning if another fingerprint was added since last app use
+- Emit a warning if another fingerprint was registered since last app use; this is a measure against a malicious user trying to add their fingerprint unnoticed to the device lock settings
 
 ### Fixed
 

--- a/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
@@ -340,6 +340,8 @@ open class BasePGPActivity : AppCompatActivity() {
                   val cipher =
                     AESEncryption.getCipher(KeyType.PERSISTENT_WITH_AUTHENTICATION)
                       ?: run {
+                        persistentPassphrases.edit { clear() }
+                        // recover from invalidated AES key
                         AESEncryption.deleteKey(KeyType.PERSISTENT_WITH_AUTHENTICATION)
                         AESEncryption.getCipher(KeyType.PERSISTENT_WITH_AUTHENTICATION)
                       }

--- a/app/src/main/java/app/passwordstore/ui/settings/PasswordSettings.kt
+++ b/app/src/main/java/app/passwordstore/ui/settings/PasswordSettings.kt
@@ -48,8 +48,18 @@ class PasswordSettings(private val activity: FragmentActivity) : SettingsProvide
         enabled = canAuthenticate
         summaryRes = R.string.unlock_password_with_pin_pref_summary
         onClick {
-          AESEncryption.deleteKey(keyType = KeyType.PERSISTENT_WITH_AUTHENTICATION)
-          activity.persistentPassphrases.edit { clear() }
+          /* Don't allow disabling biom. authentication if AES key has been invalidated.
+           * This is to prevent a malicious user from adding their fingerprint unnoticed. */
+          if (
+            !checked &&
+              AESEncryption.getCipher(keyType = KeyType.PERSISTENT_WITH_AUTHENTICATION) == null
+          ) {
+            checked = true
+            activity.sharedPrefs.edit { putBoolean(PreferenceKeys.UNLOCK_PASSWORDS_WITH_PIN, true) }
+          } else {
+            AESEncryption.deleteKey(keyType = KeyType.PERSISTENT_WITH_AUTHENTICATION)
+            activity.persistentPassphrases.edit { clear() }
+          }
           false
         }
       }


### PR DESCRIPTION
This setting can only be changed again after successful decryption of a pass entry with the PGP passphrase. This is to prevent a malicious user from registering their fingerprint unnoticed.