### PR TITLE
fix pre-launch biometric auth on Android-14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Re-enable pre-launch biometric auth option on Android-14 devices (https://github.com/android-password-store/Android-Password-Store/issues/2802)
+
 ## [1.14.1] - 2025-04-16
 
 ### Added

--- a/app/src/main/java/app/passwordstore/ui/settings/GeneralSettings.kt
+++ b/app/src/main/java/app/passwordstore/ui/settings/GeneralSettings.kt
@@ -6,7 +6,6 @@
 package app.passwordstore.ui.settings
 
 import android.content.pm.ShortcutManager
-import android.os.Build
 import androidx.core.content.edit
 import androidx.core.content.getSystemService
 import androidx.fragment.app.FragmentActivity
@@ -76,15 +75,13 @@ class GeneralSettings(private val activity: FragmentActivity) : SettingsProvider
       }
 
       // See https://github.com/android-password-store/Android-Password-Store/issues/2802
-      val disableAuth = Build.VERSION.SDK_INT == Build.VERSION_CODES.UPSIDE_DOWN_CAKE
       val canAuthenticate = BiometricAuthenticator.canAuthenticate(activity)
       switch(PreferenceKeys.BIOMETRIC_AUTH_2) {
         titleRes = R.string.pref_biometric_auth_title
         defaultValue = activity.sharedPrefs.getBoolean(PreferenceKeys.BIOMETRIC_AUTH_2, false)
-        enabled = !disableAuth && canAuthenticate
+        enabled = canAuthenticate
         summaryRes =
-          if (disableAuth) R.string.pref_biometric_auth_summary_disabled_platform
-          else if (canAuthenticate) R.string.pref_biometric_auth_summary
+          if (canAuthenticate) R.string.pref_biometric_auth_summary
           else R.string.pref_biometric_auth_summary_error
         onClick {
           enabled = false

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -251,7 +251,6 @@
   <string name="pref_biometric_auth_summary">Beim Starten der App werden Sie nach Ihrem Fingerabdruck gefragt.</string>
   <string name="pref_biometric_auth_summary_error">Fingerabdrucksensor nicht ansprechbar oder kein Fingerabdruck hinterlegt</string>
   <string name="check_devicelock_settings_dialog_message">Überprüfen Sie die Geräteeinstellungen (Gerätesperre)</string>
-  <string name="pref_biometric_auth_summary_disabled_platform">Feature wegen eines Plattformbugs nicht verfügbar</string>
   <string name="pref_title_openkeystore_clear_keyid">Lösche gespeicherte OpenKeystore SSH-Schlüssel-ID.</string>
   <string name="your_public_key">Ihr öffentlicher Schlüssel</string>
   <string name="error_generate_ssh_key">Fehler beim Erstellen des SSH-Schlüssels</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -252,7 +252,6 @@
   <string name="pref_biometric_auth_summary">Password Store will prompt you for your fingerprint when launching the app</string>
   <string name="pref_biometric_auth_summary_error">Fingerprint hardware inaccessible or no fingerprint enrolled</string>
   <string name="check_devicelock_settings_dialog_message">Check the device settings (device lock)</string>
-  <string name="pref_biometric_auth_summary_disabled_platform">Feature unavailable due to a platform bug</string>
   <string name="pref_title_openkeystore_clear_keyid">Clear remembered OpenKeystore SSH Key ID</string>
   <string name="your_public_key">Your public key</string>
   <string name="error_generate_ssh_key">Error while trying to generate the ssh-key</string>


### PR DESCRIPTION
Re-enable pre-launch biometric auth option on Android-14 devices (https://github.com/android-password-store/Android-Password-Store/issues/2802)