### PR TITLE
fix display of extra content with repeated key

### DIFF
--- a/format/common/src/main/kotlin/app/passwordstore/data/passfile/PasswordEntry.kt
+++ b/format/common/src/main/kotlin/app/passwordstore/data/passfile/PasswordEntry.kt
@@ -257,7 +257,7 @@ constructor(
         // If both key and value are not empty, we can form a pair with this so add it to
         // the map.
         // key = "ABC", value = "DEF:GHI"
-        items[key] = value
+        items.putOrAppend(key, value)
       } else {
         // If either key or value is empty, we were not able to form proper key-value pair.
         // So append the original line into an "EXTRA CONTENT" map entry


### PR DESCRIPTION
A password file may contain extra content with repeated occurrences of the same `key: '. Values associated with an identical key are now consolidated and shown in a common text box in the UI.

Fixes #414 