### PR TITLE
Add support for IronFox Nightly

### DIFF
--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
@@ -90,6 +90,7 @@ private val TRUSTED_BROWSER_CERTIFICATE_HASH =
     "com.vivaldi.browser" to arrayOf("6KeFRGVbqMCYF/cydo9WibFmLsSyvFoLwOwTjTPKPR4="),
     "app.vanadium.browser" to arrayOf("xq24uDxtTBfSkq/eVv1IilHTFv+PLBHFQQIjv/in27M="),
     "org.ironfoxoss.ironfox" to arrayOf("xeKRtaVx+cjNmpeZwslOAuyXA5SIk/LKdW1nuUIE+QQ="),
+    "org.ironfoxoss.ironfox.nightly" to arrayOf("xeKRtaVx+cjNmpeZwslOAuyXA5SIk/LKdW1nuUIE+QQ="),
   )
 
 private fun isTrustedBrowser(context: Context, appPackage: String): Boolean {
@@ -133,6 +134,7 @@ private val BROWSER_MULTI_ORIGIN_METHOD =
     "org.torproject.torbrowser" to BrowserMultiOriginMethod.WebView,
     "us.spotco.fennec_dos" to BrowserMultiOriginMethod.Field,
     "org.ironfoxoss.ironfox" to BrowserMultiOriginMethod.Field,
+    "org.ironfoxoss.ironfox.nightly" to BrowserMultiOriginMethod.Field,
   )
 
 private fun getBrowserMultiOriginMethod(appPackage: String): BrowserMultiOriginMethod =


### PR DESCRIPTION
As of https://github.com/ironfox-oss/IronFox/commit/a2c7570bdc4dc824ec3b66f4ec12f9678cbe7de9, we're now using a separate package ID for Nightly builds.

Similar to https://github.com/agrahn/Android-Password-Store/pull/317 / https://github.com/agrahn/Android-Password-Store/issues/316, this adds support for IronFox Nightly.