### PR TITLE
Allow comments in .gpg-id

### DIFF
--- a/crypto/pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPIdentifier.kt
+++ b/crypto/pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPIdentifier.kt
@@ -61,7 +61,9 @@ public sealed class PGPIdentifier {
       // Match long key IDs:
       // FF22334455667788 or 0xFF22334455667788
       val maybeLongKeyId =
-        identifier.removePrefix("0x").takeIf { it.matches("[a-fA-F\\d]{16}".toRegex()) }
+        identifier.removePrefix("0x").substringBefore("#").trimEnd().takeIf {
+          it.matches("[a-fA-F\\d]{16}".toRegex())
+        }
       if (maybeLongKeyId != null) {
         val keyId = maybeLongKeyId.toULong(HEX_RADIX)
         return KeyId(keyId.toLong())
@@ -70,7 +72,9 @@ public sealed class PGPIdentifier {
       // Match fingerprints:
       // FF223344556677889900112233445566778899 or 0xFF223344556677889900112233445566778899
       val maybeFingerprint =
-        identifier.removePrefix("0x").takeIf { it.matches("[a-fA-F\\d]{40}".toRegex()) }
+        identifier.removePrefix("0x").substringBefore("#").trimEnd().takeIf {
+          it.matches("[a-fA-F\\d]{40}".toRegex())
+        }
       if (maybeFingerprint != null) {
         // Truncating to the long key ID is not a security issue since OpenKeychain only
         // accepts


### PR DESCRIPTION
This change strips out any comments behind fingerprints and keyid's in in the .gpg-id file

I add comments to my .gpg-id file to help me remember which key belongs to which user, this change filters those out before using the keyid or fingerprint.