### PR TITLE
Allow comments in .gpg-id

### DIFF
--- a/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
@@ -38,6 +38,7 @@ import app.passwordstore.util.extensions.clipboard
 import app.passwordstore.util.extensions.getString
 import app.passwordstore.util.extensions.isInsideRepository
 import app.passwordstore.util.extensions.snackbar
+import app.passwordstore.util.extensions.substringBefore
 import app.passwordstore.util.extensions.unsafeLazy
 import app.passwordstore.util.extensions.wipe
 import app.passwordstore.util.settings.Constants
@@ -240,6 +241,9 @@ open class BasePGPActivity : AppCompatActivity() {
     val gpgIdentifiers =
       gpgIdentifierFile
         .readLines()
+        .map { // strip trailing comments
+          it.substringBefore(Regex("\\s+#"))
+        }
         .filter { it.isNotBlank() && it != "gpg-id" }
         .map { line ->
           if (line.removePrefix("0x").matches("[a-fA-F0-9]{8}".toRegex())) {

--- a/app/src/main/java/app/passwordstore/ui/passwords/PasswordFragment.kt
+++ b/app/src/main/java/app/passwordstore/ui/passwords/PasswordFragment.kt
@@ -39,6 +39,7 @@ import app.passwordstore.util.coroutines.DispatcherProvider
 import app.passwordstore.util.extensions.base64
 import app.passwordstore.util.extensions.getString
 import app.passwordstore.util.extensions.sharedPrefs
+import app.passwordstore.util.extensions.substringBefore
 import app.passwordstore.util.extensions.viewBinding
 import app.passwordstore.util.settings.AuthMode
 import app.passwordstore.util.settings.GitSettings
@@ -353,6 +354,9 @@ class PasswordFragment : Fragment(R.layout.password_recycler_view) {
     val gpgIds =
       file
         .readLines()
+        .map { // strip trailing comments
+          it.substringBefore(Regex("\\s+#"))
+        }
         .filter { it.isNotBlank() && it != "gpg-id" }
         .map { line ->
           if (line.removePrefix("0x").matches("[a-fA-F0-9]{8}".toRegex())) {

--- a/app/src/main/java/app/passwordstore/util/extensions/Extensions.kt
+++ b/app/src/main/java/app/passwordstore/util/extensions/Extensions.kt
@@ -66,6 +66,9 @@ fun String.base64(): String {
   return Base64.encodeToString(encodeToByteArray(), Base64.NO_WRAP)
 }
 
+fun String.substringBefore(delimiter: Regex, missingDelimiterValue: String = this): String =
+  delimiter.find(this)?.value?.let { this.substringBefore(it) } ?: missingDelimiterValue
+
 fun CharArray.wipe() {
   fill('\u0000')
   drop(size)


### PR DESCRIPTION
This change strips out any comments behind fingerprints and keyid's in the .gpg-id file. Complements PR #540.