### PR TITLE
Enable jgit updates on 6.x line.

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -48,10 +48,19 @@
       ],
       enabled: false,
       matchPackageNames: [
-        'org.eclipse.jgit',
         'com.squareup.logcat',
       ],
     },
+    {
+      matchManagers: [
+        'gradle',
+      ],
+      matchPackageNames: [
+        'org.eclipse.jgit',
+      ],
+      "allowedVersions": '6.x',
+      "description": 'keep jgit on 6.x, jgit 7 requires jdk17'
+    }
   ],
   customManagers: [
     {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,7 +75,7 @@ thirdparty-commons_codec = "commons-codec:commons-codec:1.20.0"
 thirdparty-compose-lints = "com.slack.lint.compose:compose-lint-checks:1.4.2"
 thirdparty-fastscroll = "me.zhanghai.android.fastscroll:library:1.3.0"
 thirdparty-flowbinding-android = { module = "io.github.reactivecircus.flowbinding:flowbinding-android", version.ref = "flowbinding" }
-# JGit upgrades also raise its minimum Java runtime requirements that we cannot satisfy on Android
+# JGit v7 upgrade also raises its minimum Java runtime requirements that we cannot satisfy on Android
 # noinspection GradleDependency
 thirdparty-jgit = "org.eclipse.jgit:org.eclipse.jgit:6.2.0.202206071550-r"
 thirdparty-kotlinResult = { module = "com.michael-bull.kotlin-result:kotlin-result", version.ref = "kotlinResult" }


### PR DESCRIPTION
This allows renovate to upgrade from jgit v6.2 to v6.10.

[jgit v7 requires JDK 17](https://projects.eclipse.org/projects/technology.jgit/releases/7.0.0), as noted in #63. 

Upgrades should be fine on 6.x line.