### PR TITLE
Disable JGit updates again. JGit v6.3+ requires Android 13+.

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -47,20 +47,11 @@
         'gradle',
       ],
       enabled: false,
-      "description": 'Packages to be excluded from updates',
-      matchPackageNames: [
-      ],
-    },
-    {
-      matchManagers: [
-        'gradle',
-      ],
+      description: 'Packages to be excluded from updates. Android 13+ required for JGit v6.3+.',
       matchPackageNames: [
         'org.eclipse.jgit',
       ],
-      "allowedVersions": '6.x',
-      "description": 'keep jgit on 6.x, jgit 7 requires jdk17'
-    }
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
Related:
#559 - investigation in here
#560 (should close after merging this)
#63 

