### PR TITLE
Test that Java runtime supports all valid crypto algorithms from user TOTP string

### DIFF
--- a/format/common/src/test/kotlin/app/passwordstore/util/totp/OtpTest.kt
+++ b/format/common/src/test/kotlin/app/passwordstore/util/totp/OtpTest.kt
@@ -101,36 +101,37 @@ class OtpTest {
   }
 
   /*
-    Ensure Java runtime supports all the algorithms required by the TOTP spec
-    HMAC-SHA-1 or HMAC-SHA-256 or HMAC-SHA-512 (all SHA2)
-    RFC 6238: https://datatracker.ietf.org/doc/html/rfc6238
-   */
+   Ensure Java runtime supports all the algorithms required by the TOTP spec
+   HMAC-SHA-1 or HMAC-SHA-256 or HMAC-SHA-512 (all SHA2)
+   RFC 6238: https://datatracker.ietf.org/doc/html/rfc6238
+  */
   @Test
   fun otpCheckCryptoSupport() {
     // more info in $JAVA_HOME/conf/security/java.security
-    val algos = listOf(
-      "KeyGenerator.HmacSHA1",
-      "KeyGenerator.HmacSHA256",
-      "KeyGenerator.HmacSHA512",
-      "Mac.HmacSHA1",
-      "Mac.HmacSHA256",
-      "Mac.HmacSHA512",
-    )
+    val algos =
+      listOf(
+        "KeyGenerator.HmacSHA1",
+        "KeyGenerator.HmacSHA256",
+        "KeyGenerator.HmacSHA512",
+        "Mac.HmacSHA1",
+        "Mac.HmacSHA256",
+        "Mac.HmacSHA512",
+      )
     for (a in algos) {
       assertNotNull(Security.getProviders(a))
     }
   }
 
   /*
-    Use this for discovering supported java.security providers
-   */
+   Use this for discovering supported java.security providers
+  */
   // @Test
   fun printJdkSupportedCrypto() {
     // https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/security/Security.html
     // also in $JAVA_HOME/conf/security/java.security
     val p = Security.getProviders()
     p.forEach {
-      println("# ${it.name} - ${it.javaClass} - ${it.info} #");
+      println("# ${it.name} - ${it.javaClass} - ${it.info} #")
       for (s in it.services.sortedBy { x -> x.type + x.algorithm }) {
         print(s.type)
         print(" - ")

--- a/format/common/src/test/kotlin/app/passwordstore/util/totp/OtpTest.kt
+++ b/format/common/src/test/kotlin/app/passwordstore/util/totp/OtpTest.kt
@@ -6,6 +6,7 @@
 package app.passwordstore.util.totp
 
 import com.github.michaelbull.result.get
+import java.security.Security
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -97,5 +98,45 @@ class OtpTest {
     assertNotNull(digitsOtp)
     assertEquals("6M3CT", issuerOtp)
     assertEquals("6M3CT", digitsOtp)
+  }
+
+  /*
+    Ensure Java runtime supports all the algorithms required by the TOTP spec
+    HMAC-SHA-1 or HMAC-SHA-256 or HMAC-SHA-512 (all SHA2)
+    RFC 6238: https://datatracker.ietf.org/doc/html/rfc6238
+   */
+  @Test
+  fun otpCheckCryptoSupport() {
+    // more info in $JAVA_HOME/conf/security/java.security
+    val algos = listOf(
+      "KeyGenerator.HmacSHA1",
+      "KeyGenerator.HmacSHA256",
+      "KeyGenerator.HmacSHA512",
+      "Mac.HmacSHA1",
+      "Mac.HmacSHA256",
+      "Mac.HmacSHA512",
+    )
+    for (a in algos) {
+      assertNotNull(Security.getProviders(a))
+    }
+  }
+
+  /*
+    Use this for discovering supported java.security providers
+   */
+  // @Test
+  fun printJdkSupportedCrypto() {
+    // https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/security/Security.html
+    // also in $JAVA_HOME/conf/security/java.security
+    val p = Security.getProviders()
+    p.forEach {
+      println("# ${it.name} - ${it.javaClass} - ${it.info} #");
+      for (s in it.services.sortedBy { x -> x.type + x.algorithm }) {
+        print(s.type)
+        print(" - ")
+        println(s.algorithm)
+      }
+      println()
+    }
   }
 }


### PR DESCRIPTION
I was playing around compiling with JDK 23, and found that JDK-23 supports SHA0 which caused OTP test to fail.

This is a simple test I created to validate that all the possible HMAC algorithms used by TOTP are supported by the JDK. To prep for one day having to refactor the TOTP code.