### PR TITLE
Remove metalava gradle plugin, following #563.

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -21,7 +21,6 @@ dependencyResolutionManagement {
       forRepository { gradlePluginPortal() }
       filter {
         includeModule("com.github.ben-manes", "gradle-versions-plugin")
-        includeModule("me.tylerbwong.gradle.metalava", "plugin")
       }
     }
     mavenCentral { mavenContent { releasesOnly() } }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -19,9 +19,7 @@ dependencyResolutionManagement {
     }
     exclusiveContent {
       forRepository { gradlePluginPortal() }
-      filter {
-        includeModule("com.github.ben-manes", "gradle-versions-plugin")
-      }
+      filter { includeModule("com.github.ben-manes", "gradle-versions-plugin") }
     }
     mavenCentral { mavenContent { releasesOnly() } }
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,6 @@ build-diffutils = "io.github.java-diff-utils:java-diff-utils:4.16"
 build-download = "de.undercouch:gradle-download-task:5.6.0"
 build-javapoet = "com.squareup:javapoet:1.13.0"
 build-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-build-metalava = "me.tylerbwong.gradle.metalava:plugin:0.3.5"
 build-moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 build-moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
 build-okhttp = "com.squareup.okhttp3:okhttp:5.3.2"

--- a/scripts/pre-push-hook.sh
+++ b/scripts/pre-push-hook.sh
@@ -13,6 +13,6 @@ while read -r local_ref local_oid remote_ref remote_oid; do
   _=$remote_ref
   _=$remote_oid
   if [ "${local_oid}" != "${ZERO}" ]; then
-    CI=true "${GRADLE_EXEC}" metalavaCheckCompatibilityRelease lint spotlessCheck test -PslimTests
+    CI=true "${GRADLE_EXEC}" lint spotlessCheck test -PslimTests
   fi
 done

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,7 +22,6 @@ pluginManagement {
       filter {
         includeModule("com.gradle", "develocity-gradle-plugin")
         includeModule("com.gradle.develocity", "com.gradle.develocity.gradle.plugin")
-        includeModule("me.tylerbwong.gradle.metalava", "plugin")
         /* commented out for f-droid */
         /*        includeModule(
           "org.gradle.toolchains.foojay-resolver-convention",


### PR DESCRIPTION
Metalava was used to guarantee binary/API compatibility with the PublishedAndroidLibraryPlugin.

I think this was used for the autofill-parser?

Since the plugin was removed in #563, remove metalava.