### PR TITLE
fix release build

### DIFF
--- a/ui/compose/build.gradle.kts
+++ b/ui/compose/build.gradle.kts
@@ -24,4 +24,5 @@ dependencies {
   api(libs.compose.ui.core)
   implementation(libs.androidx.core.ktx)
   implementation(libs.compose.ui.tooling)
+  implementation(libs.androidx.material)
 }


### PR DESCRIPTION
- fix release build failure caused by proguard minifier removing resources

allows the following command to complete successfully ✅ 
```bash
./gradlew assembleRelease
```

prerequisites:
`keystore.properties` is present in the project root with following content

```bash
keyAlias=myKeyAlias
keyPassword=myKeyPassword
storeFile=path-to-keystore.jks
storePassword=myKeySecretPassword
```
_without_ the fix the following error occurs:

```bash
./gradlew assembleRelease

> Configure project :build-logic
WARNING: Unsupported Kotlin plugin version.
The `embedded-kotlin` and `kotlin-dsl` plugins rely on features of Kotlin `2.2.20` that might work differently than in the requested version `2.2.21`.
Type-safe project accessors is an incubating feature.

> Task :app:lintVitalReportFreeRelease
Lint found no errors or warnings

18 errors/warnings were listed in the baseline file (projects/android/Android-Password-Store-agrahn/app/lint-baseline.xml) but not found in the project; perhaps they have been fixed?

Note: The baseline was created using a different target/variant than it was checked against.
Creation variant: lint
Current variant: lintVitalRelease

> Task :ui:compose:verifyReleaseResources FAILED
Kotlin build report is written to file:///projects/android/Android-Password-Store-agrahn/build/reports/kotlin-build/APS-build-2026-01-11-08-47-00-0.txt

[Incubating] Problems report is available at: file:///projects/android/Android-Password-Store-agrahn/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':ui:compose:verifyReleaseResources'.
> A failure occurred while executing com.android.build.gradle.tasks.VerifyLibraryResourcesTask$Action
   > Android resource linking failed
     ERROR: projects/android/Android-Password-Store-agrahn/ui/compose/build/intermediates/merged_res/release/mergeReleaseResources/drawable/ic_arrow_back_24dp.xml:13: AAPT: error: resource attr/colorOnBackground (aka app.passwordstore.ui.compose:attr/colorOnBackground) not found.
         
     ERROR: projects/android/Android-Password-Store-agrahn/ui/compose/build/intermediates/merged_res/release/mergeReleaseResources/drawable/ic_search_24dp.xml:13: AAPT: error: resource attr/colorOnBackground (aka app.passwordstore.ui.compose:attr/colorOnBackground) not found.
         

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Get more help at https://help.gradle.org.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/9.2.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD FAILED in 5s
201 actionable tasks: 9 executed, 3 from cache, 189 up-to-date
Configuration cache entry stored.
```