### PR TITLE
fix release build failure

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,6 +30,10 @@ android {
   packaging { resources.excludes.add("META-INF/versions/**") }
 }
 
+// This seems to fix a release build failure after updating
+// kotlin-2.3.0
+composeCompiler { includeComposeMappingFile.set(false) }
+
 dependencies {
   implementation(platform(libs.compose.bom))
   kapt(libs.dagger.hilt.compiler)

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,6 @@ kapt.incremental.apt=true
 kapt.include.compile.classpath=false
 
 # New incremental compilation for Kotlin
-kotlin.compiler.preciseCompilationResultsBackup=true
 kotlin.build.report.output=file
 kotlin.compiler.suppressExperimentalICOptimizationsWarning=true
 


### PR DESCRIPTION
After updating kotlin and compose to v2.3.0 the following error occurred:

Execution failed for task ':app:produceFreeReleaseComposeMapping'.
> A failure occurred while executing org.jetbrains.kotlin.compose.compiler.gradle.internal.ProduceMappingFileTask$Action
   > Unsupported class file major version 69