### PR TITLE
remove special naming prefix `free` for builds and tasks

### DIFF
--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Build project
       shell: bash
-      run: ./gradlew assembleFreeRelease
+      run: ./gradlew assembleRelease
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0

--- a/.github/workflows/deploy_github_releases.yml
+++ b/.github/workflows/deploy_github_releases.yml
@@ -22,13 +22,13 @@ jobs:
 
     - name: Build release binaries
       shell: bash
-      run: ./gradlew :app:assembleFreeRelease
+      run: ./gradlew :app:assembleRelease
 
-    - name: Upload free release APK
+    - name: Upload release APK
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
-        name: APS Free Release APK
-        path: app/build/outputs/apk/free/release/app-free-release.apk
+        name: APS Release APK
+        path: app/build/outputs/apk/release/app-release.apk
 
     - name: Clean secrets
       if: "${{ always() }}"
@@ -42,11 +42,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Get Free Release APK
+      - name: Get Release APK
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: APS Free Release APK
-          path: artifacts/free
+          name: APS Release APK
+          path: artifacts
 
 #      - name: Get Changelog Entry
 #        id: changelog_reader
@@ -72,12 +72,12 @@ jobs:
         shell: bash
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
-      - name: Upload Free Release Apk
+      - name: Upload Release Apk
         uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./artifacts/free/app-free-release.apk
-          asset_name: APS-free_${{ steps.get_version.outputs.VERSION }}.apk
+          asset_path: ./artifacts/app-release.apk
+          asset_name: APS_${{ steps.get_version.outputs.VERSION }}.apk
           asset_content_type: application/vnd.android.package-archive

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Build release app
       shell: bash
-      run: ./gradlew collectFreeReleaseApks bundleFreeRelease
+      run: ./gradlew collectReleaseApks bundleRelease
       env:
         SNAPSHOT: "true"
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Build debug APKs
         shell: bash
-        run: ./gradlew assembleFreeDebug
+        run: ./gradlew assembleDebug
 
       - name: Upload Kotlin build report
         if: "${{ always() }}"

--- a/build-logic/src/main/kotlin/app/passwordstore/gradle/ApplicationPlugin.kt
+++ b/build-logic/src/main/kotlin/app/passwordstore/gradle/ApplicationPlugin.kt
@@ -7,8 +7,8 @@
 
 package app.passwordstore.gradle
 
-import app.passwordstore.gradle.flavors.FlavorDimensions
-import app.passwordstore.gradle.flavors.ProductFlavors
+// import app.passwordstore.gradle.flavors.FlavorDimensions
+// import app.passwordstore.gradle.flavors.ProductFlavors
 import app.passwordstore.gradle.signing.configureBuildSigning
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.gradle.AppPlugin
@@ -53,8 +53,8 @@ class ApplicationPlugin : Plugin<Project> {
         }
       }
 
-      flavorDimensions.add(FlavorDimensions.FREE)
-      productFlavors { register(ProductFlavors.FREE) {} }
+      //      flavorDimensions.add(FlavorDimensions.FREE)
+      //      productFlavors { register(ProductFlavors.FREE) {} }
 
       project.configureBuildSigning()
     }


### PR DESCRIPTION
There is only one product flavour (the former `free` variant), so prefixing tasks and build outputs with `free` is redundant.