### PR TITLE
Add IceRaven browser to trusted browsers list

### DIFF
--- a/app/src/main/res/xml/oreo_autofill_service.xml
+++ b/app/src/main/res/xml/oreo_autofill_service.xml
@@ -15,6 +15,7 @@
   <compatibility-package android:name="com.microsoft.emmx" />
   <compatibility-package android:name="com.opera.mini.native" />
   <compatibility-package android:name="com.opera.mini.native.beta" />
+  <compatibility-package android:name="io.github.forkmaintainers.iceraven" />
   <compatibility-package android:name="org.bromite.bromite" />
   <compatibility-package
     android:name="org.mozilla.fennec_fdroid"

--- a/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
+++ b/autofill-parser/src/main/java/com/github/androidpasswordstore/autofillparser/FeatureAndTrustDetection.kt
@@ -65,6 +65,11 @@ private val TRUSTED_BROWSER_CERTIFICATE_HASH =
     "com.opera.mini.native" to arrayOf("V6y8Ul8bLr0ZGWzW8BQ5fMkQ/RiEHgroUP68Ph5ZP/I="),
     "com.opera.mini.native.beta" to arrayOf("V6y8Ul8bLr0ZGWzW8BQ5fMkQ/RiEHgroUP68Ph5ZP/I="),
     "com.opera.touch" to arrayOf("qtjiBNJNF3k0yc0MY8xqo4779CxKaVcJfiIQ9X+qZ6o="),
+    "io.github.forkmaintainers.iceraven" to // IceRaven (Firefox fork)
+      arrayOf(
+        "nA0iN59Ie3Ck+fi+wBc8+RoWRPCPkzhbW3gs43ZguoE=", // Original (GitHub release)
+        "eRN80/UC/Z35sLtql9UY+ig0XwP/8M76QJ9omrs54hQ=", // GoodyOG's OLED fork (GitHub release)
+      ),
     "org.bromite.bromite" to arrayOf("4e5c0HbXsNyEyytF+3i4bfLrOaO2xWuj3CkqXgw7lQQ="),
     "org.cromite.cromite" to arrayOf("Yz+kHYIR1tCRaoGbiWaMbekuZCMtpn+dFv2Bw7fpI/8="),
     "org.gnu.icecat" to arrayOf("wi2iuVvK/WYZUzd2g0Qzn9ef3kAisQURZ8U1WSMTkcM="),


### PR DESCRIPTION
Original firefox fork:
https://github.com/fork-maintainers/iceraven-browser

OLED displays fork:
https://github.com/GoodyOG/Iceraven-OLED