### PR TITLE
markup for add. password-type fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to this project will be documented in this file
 
 - PGP key option for authenticating and connecting via SSH. The PGP key does not need to provide a dedicated authentication subkey; the signing subkey and even the primary certification key are equally usable for that purpose. The authentication key is always picked first, if available, while the signing subkey and the primary key serve as fallbacks
 - The PGP key manager now lets you set individual passphrases for the subkeys of a PGP key
+- Declare sensitive fields of extra content using `gopass` syntax or by marking keys up with asterisks: `*key 4*: sensitive content`
+````
+unsafe-keys: key 1, key_2, key-3, ...,
+key 1: something
+key_2: more stuff
+...
+````
 - Allow custom port setting for Git via http
 
 ### Fixed

--- a/app/src/main/java/app/passwordstore/ui/crypto/DecryptActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/DecryptActivity.kt
@@ -247,9 +247,11 @@ class DecryptActivity : BasePGPActivity() {
       }
 
       entry.extraContent.forEach { (key, value) ->
-        /* TODO: for keys denoting sensitive content, like additional passwords, "PIN",
-         * "CVC" and such, create masked items with FieldItem.createPasswordField */
-        if (key != PasswordEntry.EXTRA_CONTENT) items.add(FieldItem.createFreeformField(key, value))
+        if (key != PasswordEntry.EXTRA_CONTENT) {
+          if (key in entry.unsafeKeys || key.lowercase() in listOf("password", "secret", "pass"))
+            items.add(FieldItem.createPasswordField(key, value))
+          else items.add(FieldItem.createFreeformField(key, value))
+        }
       }
 
       entry.extraContent.forEach { (key, value) ->

--- a/format/common/src/main/kotlin/app/passwordstore/data/passfile/PasswordEntry.kt
+++ b/format/common/src/main/kotlin/app/passwordstore/data/passfile/PasswordEntry.kt
@@ -44,6 +44,9 @@ constructor(
   /** The username for this entry. Can be null. */
   public val username: CharArray?
 
+  /** The username for this entry. Can be null. */
+  public lateinit var unsafeKeys: MutableSet<String>
+
   /** The totp entry extracted from the decrypted password file */
   private val totpString: String
 
@@ -103,13 +106,22 @@ constructor(
     val (foundUsername, passContentWithoutPasswordsAndFirstUsername) =
       findAndStripFirstUsername(passContentWithoutPasswords)
     username = foundUsername
+
     extraContentChars = passContentWithoutPasswordsAndFirstUsername.joinToCharArray('\n')
+
     val (foundTotp, extraContentWithoutAuthData) =
       findAndStripTotp(passContentWithoutPasswordsAndFirstUsername)
     totpString = foundTotp?.let { String(it) } ?: ""
     foundTotp?.fill('\u0000')
-    extraContent = generateExtraContentPairs(extraContentWithoutAuthData)
+
+    val (unsafe, extraContentWithoutAuthDataAndUnsafeKeywords) =
+      findAndStripUnsafeKeys(extraContentWithoutAuthData)
+    unsafeKeys = unsafe
+
+    extraContent = generateExtraContentPairs(extraContentWithoutAuthDataAndUnsafeKeywords)
+
     allLines.forEach { it?.fill('\u0000') }
+
     // Verify the TOTP secret is valid and disable TOTP if not.
     val secret = totpFinder.findSecret(totpString)
     totpSecret =
@@ -140,6 +152,7 @@ constructor(
       lines = lines.minus(lines[0])
     }
     for (line in lines) {
+      if (line.isBlank()) break
       for (prefix in PASSWORD_FIELDS) {
         if (line.startsWith(prefix, ignoreCase = true)) {
           password = line.copyOfRange(prefix.length, line.size).trimStart()
@@ -172,6 +185,7 @@ constructor(
     var lines = passContent
     var username: CharArray? = null
     for (line in passContent) {
+      if (line.isBlank()) break
       for (prefix in USERNAME_FIELDS) {
         if (line.startsWith(prefix, ignoreCase = true)) {
           username = line.copyOfRange(prefix.length, line.size).trimStart()
@@ -182,6 +196,31 @@ constructor(
       username?.let { break }
     }
     return Pair(username, lines)
+  }
+
+  /* gopass-way of declaring sensitive extra-content keys denoting fields that should be displayed
+   * as passwords:
+   *
+   *   unsafe-keys: key_1, key_2, ...
+   *
+   * such keys are placed in the returned string list */
+  private fun findAndStripUnsafeKeys(
+    passContent: List<CharArray>
+  ): Pair<MutableSet<String>, List<CharArray>> {
+    var lines = passContent
+    val unsafe = mutableSetOf<String>()
+    for (line in passContent) {
+      if (line.isBlank()) break
+      if (line.startsWith(UNSAFE_KEYS, ignoreCase = true)) {
+        unsafe.addAll(
+          line.copyOfRange("unsafe-keys:".length, line.size).splitToCharArrayListAt(',').map {
+            String(it).trim()
+          }
+        )
+        lines = lines.minus(line)
+      }
+    }
+    return Pair(unsafe, lines)
   }
 
   private fun findAndStripTotp(passContent: List<CharArray>): Pair<CharArray?, List<CharArray>> {
@@ -232,7 +271,17 @@ constructor(
           else charArrayOf()
         if (k.isBlank() || k.startsWith(" ") || k.startsWith("\\t") || extraContentStarted)
           extraContentLines.add(line)
-        else items.putOrAppend(String(k).trimEnd(), v.trimStart().trimEnd())
+        else {
+          val kk = String(k).trimEnd()
+          val key =
+            if (kk.startsWith("*") && kk.endsWith("*")) {
+              kk.substring(1, kk.length - 1).let {
+                unsafeKeys.add(it)
+                it
+              }
+            } else kk
+          items.putOrAppend(key, v.trimStart().trimEnd())
+        }
       } else {
         if (line.isBlank()) {
           extraContentStarted = true
@@ -308,8 +357,11 @@ constructor(
         "identity:",
       )
 
+    private val UNSAFE_KEYS: String = "unsafe-keys:"
+
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     public val PASSWORD_FIELDS: Array<String> = arrayOf("password:", "secret:", "pass:")
+
     private const val THOUSAND_MILLIS = 1000L
   }
 }


### PR DESCRIPTION
declare sensitive fields the gopass way:

    unsafe-keys: key-1, key 2, ...
    key-1: masked-value
    key 2: another one

or mark them up with:

    *key 3*: yet another sensitive value

Such fields will be displayed as password fields with masked content.

This resolves #710.