### PR TITLE
CredentialFinder: Uncheck "remember passphrase" checkbox by default

### DIFF
--- a/app/src/main/java/app/passwordstore/util/git/operation/CredentialFinder.kt
+++ b/app/src/main/java/app/passwordstore/util/git/operation/CredentialFinder.kt
@@ -54,7 +54,7 @@ class CredentialFinder(
   private var retries = 0
 
   private var rememberPassphraseVisible = View.VISIBLE
-  private var rememberPassphrase = true
+  private var rememberPassphrase = false
   private var cachedPassphrase: CharArray? = null
 
   val credentialPref: String? =


### PR DESCRIPTION
Presently, users who prefer not to save server credentials must uncheck the "remember passphrase" checkbox each time they enter server credentials. Unchecking that checkbox by default will minimally impact users who do save server credentials, as they normally only enter server credentials once.

I have traced the PGP and non-PGP code paths and manually tested server auth with SSH and PGP keys. This small code change seems to be all that is necessary.