### PR TITLE
disabling ssh authentication with KeyStore keys

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,7 +50,6 @@
       description: 'Packages to be excluded from updates',
       matchPackageNames: [
         'org.eclipse.jgit', // Android 13+ required for JGit v6.3+
-        'com.hierynomus', // version > 0.39.0 does not work with KeyStore provided auth keys
       ],
     },
   ],

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -5,14 +5,14 @@
         id="InvalidPackage"
         message="Invalid package reference in library; not included in Android: `javax.naming.directory`. Referenced from `org.bouncycastle.cert.dane.fetcher.JndiDANEFetcherFactory`.">
         <location
-            file="$GRADLE_USER_HOME/caches/modules-2/files-2.1/org.bouncycastle/bcpkix-jdk18on/1.78.1/17b3541f736df97465f87d9f5b5dfa4991b37bb3/bcpkix-jdk18on-1.78.1.jar"/>
+            file="$GRADLE_USER_HOME/caches/modules-2/files-2.1/org.bouncycastle/bcpkix-jdk18on/1.80/5277dfaaef2e92ce1d802499599a0ca7488f86e6/bcpkix-jdk18on-1.80.jar"/>
     </issue>
 
     <issue
         id="InvalidPackage"
         message="Invalid package reference in library; not included in Android: `javax.naming`. Referenced from `org.bouncycastle.cert.dane.fetcher.JndiDANEFetcherFactory.1`.">
         <location
-            file="$GRADLE_USER_HOME/caches/modules-2/files-2.1/org.bouncycastle/bcpkix-jdk18on/1.78.1/17b3541f736df97465f87d9f5b5dfa4991b37bb3/bcpkix-jdk18on-1.78.1.jar"/>
+            file="$GRADLE_USER_HOME/caches/modules-2/files-2.1/org.bouncycastle/bcpkix-jdk18on/1.80/5277dfaaef2e92ce1d802499599a0ca7488f86e6/bcpkix-jdk18on-1.80.jar"/>
     </issue>
 
     <issue

--- a/app/src/main/java/app/passwordstore/ui/settings/RepositorySettings.kt
+++ b/app/src/main/java/app/passwordstore/ui/settings/RepositorySettings.kt
@@ -220,7 +220,9 @@ class RepositorySettings(private val activity: FragmentActivity) : SettingsProvi
           }
         }
         pref(PreferenceKeys.SSH_KEYGEN) {
+          enabled = false
           titleRes = R.string.pref_ssh_keygen_title
+          summaryRes = R.string.pref_ssh_keygen_summary_disabled_platform
           onClick {
             sshKeyAction.launch(Intent(activity, SshKeyGenActivity::class.java))
             true

--- a/app/src/main/java/app/passwordstore/util/git/operation/GitOperation.kt
+++ b/app/src/main/java/app/passwordstore/util/git/operation/GitOperation.kt
@@ -5,6 +5,7 @@
 package app.passwordstore.util.git.operation
 
 import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.FragmentActivity
 import app.passwordstore.R
@@ -146,13 +147,15 @@ abstract class GitOperation(protected val callingActivity: FragmentActivity) {
   }
 
   private fun onMissingSshKeyFile() {
-    MaterialAlertDialogBuilder(callingActivity)
-      .setTitle(R.string.ssh_preferences_dialog_title)
-      .setMessage(R.string.ssh_preferences_dialog_text)
-      .setNeutralButton(R.string.button_label_import) { _, _ -> getSshKey(false) }
-      .setNegativeButton(R.string.ssh_preferences_dialog_generate) { _, _ -> getSshKey(true) }
-      .setPositiveButton(R.string.ssh_preferences_dialog_pgp_key) { _, _ -> usePgpKey() }
-      .show()
+    var dialog =
+      MaterialAlertDialogBuilder(callingActivity)
+        .setTitle(R.string.ssh_preferences_dialog_title)
+        .setMessage(R.string.ssh_preferences_dialog_text)
+        .setNeutralButton(R.string.button_label_import) { _, _ -> getSshKey(false) }
+        .setNegativeButton(R.string.ssh_preferences_dialog_generate) { _, _ -> getSshKey(true) }
+        .setPositiveButton(R.string.ssh_preferences_dialog_pgp_key) { _, _ -> usePgpKey() }
+        .show()
+    dialog.getButton(AlertDialog.BUTTON_NEGATIVE).isEnabled = false
   }
 
   suspend fun executeAfterAuthentication(authMode: AuthMode): Result<Unit, Throwable> {

--- a/app/src/main/java/app/passwordstore/util/git/sshj/SshjConfig.kt
+++ b/app/src/main/java/app/passwordstore/util/git/sshj/SshjConfig.kt
@@ -4,6 +4,7 @@
  */
 package app.passwordstore.util.git.sshj
 
+// import net.schmizz.sshj.common.SecurityUtils
 import app.passwordstore.util.log.LogcatLogger
 import com.github.michaelbull.result.runCatching
 import com.hierynomus.sshj.key.KeyAlgorithms
@@ -19,7 +20,6 @@ import logcat.logcat
 import net.schmizz.keepalive.KeepAliveProvider
 import net.schmizz.sshj.ConfigImpl
 import net.schmizz.sshj.common.LoggerFactory
-import net.schmizz.sshj.common.SecurityUtils
 import net.schmizz.sshj.transport.compression.NoneCompression
 import net.schmizz.sshj.transport.kex.Curve25519SHA256
 import net.schmizz.sshj.transport.kex.Curve25519SHA256.FactoryLibSsh
@@ -53,11 +53,12 @@ fun setUpBouncyCastleForSshj() {
     "JCE providers: ${Security.getProviders().joinToString { "${it.name} (${it.version})" }}"
   }
 
-  /* Prevent sshj from forwarding all cryptographic operations to BC in case of KeyStore
-   * provided keys. */
   if (SshKey.type == SshKey.Type.KeystoreNative) {
-    SecurityUtils.setRegisterBouncyCastle(false)
-    SecurityUtils.setSecurityProvider(null)
+    SshKey.delete() // disabling KeyStore-generated keys (platform bug, 2026)
+    /* Prevent sshj from forwarding all cryptographic operations to BC in case of KeyStore
+     * provided keys. */
+    // SecurityUtils.setRegisterBouncyCastle(false)
+    // SecurityUtils.setSecurityProvider(null)
   }
 }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -102,6 +102,7 @@
   <string name="pref_edit_git_config">Lokale Git-Konfiguration &amp; Dienstprogramme</string>
   <string name="pref_ssh_use_pgp_key_title">PGP-Schlüssel verwenden</string>
   <string name="pref_ssh_keygen_title">Erstelle SSH-Schlüsselpaar</string>
+  <string name="pref_ssh_keygen_summary_disabled_platform">Funktion wegen eines Plattformbugs nicht verfügbar</string>
   <string name="pref_import_ssh_key_title">Importiere SSH-Schlüssel</string>
   <string name="pref_ssh_see_key_title">Zeige den öffentlichen Schlüssel an</string>
   <string name="pref_git_delete_repo_title">Repository löschen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,6 +103,7 @@
   <string name="pref_edit_git_config">Local Git config &amp; utilities</string>
   <string name="pref_ssh_use_pgp_key_title">Use PGP key</string>
   <string name="pref_ssh_keygen_title">Generate SSH key pair</string>
+  <string name="pref_ssh_keygen_summary_disabled_platform">Feature unavailable due to a platform bug</string>
   <string name="pref_import_ssh_key_title">Import SSH key</string>
   <string name="pref_ssh_see_key_title">View public key</string>
   <string name="pref_git_delete_repo_title">Delete repository</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,9 +86,7 @@ thirdparty-modernAndroidPrefs = "de.maxr1998:modernandroidpreferences:2.4.0-beta
 thirdparty-pgpainless = "org.pgpainless:pgpainless-core:2.0.2"
 thirdparty-slack-lints = "com.slack.lint:slack-lint-checks:0.11.1"
 thirdparty-slf4j-api = { module = "org.slf4j:slf4j-api", version = { strictly = "[1.7, 1.8[", prefer = "1.7.36" } }
-# v0.40.0 does not work with KeyStore provided keys anymore after Google Play Services update at the beginning of 2026
-# noinspection GradleDependency
-thirdparty-sshj = "com.hierynomus:sshj:0.39.0"
+thirdparty-sshj = "com.hierynomus:sshj:0.40.0"
 thirdparty-uri = "com.eygraber:uri-kmp:0.0.21"
 
 [bundles]


### PR DESCRIPTION
Due to a platform bug introduced with a Google Play Services update in early 2026, the use of Android Keystore-generated keys for SSH authentication had to be disabled. Otherwise, the more modern Ed25519 keys provided via the new PGP key option for authentication cannot be used.