### PR TITLE
prevent accidental overwriting password files after edit

### DIFF
--- a/app/src/main/java/app/passwordstore/ui/crypto/DecryptActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/DecryptActivity.kt
@@ -33,7 +33,9 @@ import com.github.michaelbull.result.getOrThrow
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.nio.file.Paths
 import javax.inject.Inject
+import kotlin.io.path.pathString
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -184,7 +186,7 @@ class DecryptActivity : BasePGPActivity() {
     encryptedEntryChars?.let { encrypted ->
       val intent = Intent(this, PasswordCreationActivity::class.java)
       intent.action = Intent.ACTION_VIEW
-      intent.putExtra(EXTRA_FILE_PATH, relativeParentPath)
+      intent.putExtra(EXTRA_FILE_PATH, Paths.get(fullPath).parent.pathString)
       intent.putExtra(EXTRA_REPO_PATH, repoPath)
       intent.putExtra(PasswordCreationActivity.EXTRA_FILE_NAME, name)
       intent.putExtra(PasswordCreationActivity.EXTRA_ENTRY, encrypted)

--- a/app/src/main/java/app/passwordstore/ui/crypto/PasswordCreationActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/PasswordCreationActivity.kt
@@ -69,19 +69,14 @@ import com.google.zxing.qrcode.QRCodeReader
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
-import java.io.File
 import java.io.IOException
 import java.nio.CharBuffer
 import java.nio.file.Paths
 import javax.inject.Inject
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.createDirectories
-import kotlin.io.path.deleteIfExists
 import kotlin.io.path.exists
-import kotlin.io.path.isSameFileAs
-import kotlin.io.path.nameWithoutExtension
 import kotlin.io.path.pathString
-import kotlin.io.path.relativeTo
 import kotlin.io.path.writeBytes
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -101,7 +96,6 @@ class PasswordCreationActivity : BasePGPActivity() {
     intent.getBooleanExtra(EXTRA_GENERATE_PASSWORD, false)
   }
   private val editing by unsafeLazy { intent.getBooleanExtra(EXTRA_EDITING, false) }
-  private var oldCategory: String? = null
   private var copy: Boolean = false
 
   private val otpImportAction =
@@ -191,10 +185,10 @@ class PasswordCreationActivity : BasePGPActivity() {
         ) { requestKey, bundle ->
           if (requestKey == OTP_RESULT_REQUEST_KEY) {
             val contents = bundle.getString(RESULT)
-            binding.extraContent.text?.let { currentExtras ->
+            extraContent.text?.let { currentExtras ->
               if (currentExtras.isNotEmpty() && currentExtras.last() != '\n')
-                binding.extraContent.append("\n$contents")
-              else binding.extraContent.append(contents)
+                extraContent.append("\n$contents")
+              else extraContent.append(contents)
             }
           }
         }
@@ -242,7 +236,6 @@ class PasswordCreationActivity : BasePGPActivity() {
       directory.inputType = InputType.TYPE_NULL
       val relPath = PasswordRepository.getRelativePath(fullPath, repoPath)
       directory.setText(if (relPath.isEmpty()) "/" else relPath)
-      oldCategory = relPath
 
       directory.setOnClickListener {
         val intent = Intent(this@PasswordCreationActivity, SelectFolderActivity::class.java)
@@ -336,9 +329,6 @@ class PasswordCreationActivity : BasePGPActivity() {
       R.id.save_password -> {
         copy = false
         requireKeysExist {
-          val destDir =
-            File(PasswordRepository.getRepositoryDirectory(), binding.directory.text.toString())
-          if (!destDir.isDirectory() && !destDir.isFile()) destDir.mkdirs()
           requireEncryptionKeysExist(binding.directory.text.toString()) { ids -> encrypt(ids) }
         }
       }
@@ -388,7 +378,6 @@ class PasswordCreationActivity : BasePGPActivity() {
   /** Encrypts the password and the extra content */
   private fun encrypt(identifiers: List<PGPIdentifier>) {
     with(binding) {
-      val oldName = suggestedName
       val editName = filename.text.toString().trim()
       var editUsername = username.text?.let { CharArray(it.length) { i -> it[i] } } ?: charArrayOf()
       val editPass = password.text?.let { CharArray(it.length) { i -> it[i] } } ?: charArrayOf()
@@ -436,30 +425,18 @@ class PasswordCreationActivity : BasePGPActivity() {
       // pass enters the key ID into `.gpg-id`.
       val gpgIdentifiers = getPGPIdentifiers(directory.text.toString())
       if (gpgIdentifiers.isNullOrEmpty()) return@with
-      val path =
-        when {
-          // If we allowed the user to edit the relative path, we have to consider it here
-          // instead of fullPath.
-          directoryInputLayout.isEnabled -> {
-            val editRelativePath = directory.text.toString().trim()
-            if (editRelativePath.isEmpty()) {
-              snackbar(message = resources.getString(R.string.path_toast_text))
-              return
-            }
-            val passwordDirectory = Paths.get(repoPath, editRelativePath.trim('/'))
-            passwordDirectory.createDirectories()
-            if (!passwordDirectory.exists()) {
-              snackbar(
-                message =
-                  "Failed to create directory ${passwordDirectory.relativeTo(Paths.get(repoPath)).pathString}"
-              )
-              return
-            }
 
-            "${passwordDirectory.pathString}/$editName.gpg"
-          }
-          else -> "$fullPath/$editName.gpg"
+      val path = run { // password item's full file path string
+        val editRelativePath = directory.text.toString().trim()
+        val passwordDirectory = Paths.get(repoPath, editRelativePath.trim('/'))
+        passwordDirectory.createDirectories() // ensure destination dir exists
+        if (!passwordDirectory.exists()) { // should not happen
+          snackbar(message = "Failed to create directory ${editRelativePath.trimEnd('/')}")
+          return
         }
+
+        "${passwordDirectory.pathString}/$editName.gpg"
+      }
 
       lifecycleScope.launch(dispatcherProvider.main()) {
         runCatching {
@@ -498,11 +475,13 @@ class PasswordCreationActivity : BasePGPActivity() {
             val passwordFile = Paths.get(path)
             // If we're not editing, this file should not already exist!
             // Additionally, if we were editing and the incoming and outgoing
-            // filenames differ, it means we renamed. Ensure that the target
+            // file paths differ, it means we renamed. Ensure that the target
             // doesn't already exist to prevent an accidental overwrite.
             if (
-              (!editing || (editing && suggestedName != passwordFile.nameWithoutExtension)) &&
-                passwordFile.exists()
+              (!editing ||
+                (editing &&
+                  "${fullPath.trimEnd('/')}/$suggestedName.gpg" !=
+                    passwordFile.absolutePathString())) && passwordFile.exists()
             ) {
               snackbar(message = getString(R.string.password_creation_duplicate_error))
               return@runCatching
@@ -519,7 +498,7 @@ class PasswordCreationActivity : BasePGPActivity() {
 
             // associate the new password name with the last name's timestamp in history
             val preference = getSharedPreferences("recent_password_history", Context.MODE_PRIVATE)
-            val oldFilePathHash = "$repoPath/${oldCategory?.trim('/')}/$suggestedName.gpg".base64()
+            val oldFilePathHash = "${fullPath.trimEnd('/')}/$suggestedName.gpg".base64()
             val timestamp = preference.getString(oldFilePathHash)
             if (timestamp != null) {
               preference.edit {
@@ -557,28 +536,6 @@ class PasswordCreationActivity : BasePGPActivity() {
             editUsername?.wipe()
             editExtra?.wipe()
 
-            if (
-              directoryInputLayout.isVisible &&
-                directoryInputLayout.isEnabled &&
-                oldName != editName
-            ) {
-              val oldPath = Paths.get(repoPath, oldCategory?.trim('/') ?: "", "$oldName.gpg")
-              if (
-                oldPath.exists() && !oldPath.isSameFileAs(passwordFile) && !oldPath.deleteIfExists()
-              ) {
-                setResult(RESULT_CANCELED)
-                MaterialAlertDialogBuilder(this@PasswordCreationActivity)
-                  .setTitle(R.string.error)
-                  .setMessage(
-                    getString(R.string.password_creation_file_delete_fail_message, oldName)
-                  )
-                  .setCancelable(false)
-                  .setPositiveButton(android.R.string.ok) { _, _ -> finish() }
-                  .show()
-                return@runCatching
-              }
-            }
-
             val commitMessageRes =
               if (editing) R.string.git_commit_edit_text else R.string.git_commit_add_text
             lifecycleScope.launch {
@@ -590,7 +547,7 @@ class PasswordCreationActivity : BasePGPActivity() {
                 )
                 .onOk {
                   setResult(RESULT_OK, returnIntent)
-                  var dialog =
+                  val dialog =
                     MaterialAlertDialogBuilder(this@PasswordCreationActivity)
                       .setCancelable(false)
                       .setPositiveButton(android.R.string.ok) { _, _ -> finish() }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -39,7 +39,6 @@
     <string name="git_commit_gpg_id">Inicialitza IDs de PGP a %1$s.</string>
     <string name="clipboard_copied_text">Copiat al porta‑retalls</string>
     <string name="file_toast_text">Indiqueu un nom de fitxer</string>
-    <string name="path_toast_text">Indiqueu una ruta de fitxer</string>
     <string name="empty_toast_text">No podeu usar una contrasenya o contingut extra buit</string>
     <string name="jgit_error_dialog_title">S\'ha produït un error a l\'operació Git</string>
     <string name="ssh_preferences_dialog_text">Importeu o genereu el fitxer de clau SSH a les preferències</string>
@@ -253,7 +252,6 @@
     <string name="preference_custom_public_suffixes_summary">L\'emplenament automàtic distingirà subdominis d\'aquests dominis</string>
     <string name="preference_custom_public_suffixes_hint">company.com\npersonal.com</string>
     <string name="password_creation_file_write_fail_message">No s\'ha pogut escriute el fitxer de contrasenya al magatzem, prova un altre cop.</string>
-    <string name="password_creation_file_delete_fail_message">No s\'ha pogut eliminar el fitxer de contrasenya %1$s del magatzem, prova a suprimir-lo manualment.</string>
     <string name="password_creation_duplicate_error">El fitxer ja existeix, usa un nom diferent</string>
     <string name="add_otp">Afegeix OTP</string>
     <string name="otp_import_success">S\'ha importat al configuració OTP correctament</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -48,7 +48,6 @@
   <!-- PGPHandler -->
   <string name="clipboard_copied_text">In die Zwischenablage kopiert.</string>
   <string name="file_toast_text">Bitte setzen Sie einen Dateinamen.</string>
-  <string name="path_toast_text">Bitte setzen Sie einen Pfad.</string>
   <string name="empty_toast_text">Sie müssen mindestens ein Passwort oder Zusatzangaben eintragen.</string>
 
   <!-- Git Async Task -->
@@ -327,7 +326,6 @@
   <string name="password_creation_file_encryption_failed_ids_message">\n\nVerschlüsselung fehlgeschlagen für%1$s</string>
   <string name="password_creation_file_encryption_failed_expired_key">Schlüssel abgelaufen</string>
   <string name="password_creation_file_write_fail_message">Fehler beim Speichern der Passwortdatei im Password Store, bitte versuchen Sie es erneut.</string>
-  <string name="password_creation_file_delete_fail_message">Fehler beim Löschen der Passwortdatei %1$s aus dem Password Store, bitte löschen Sie die Datei von Hand.</string>
   <string name="password_creation_unusable_encryption_key_error_message">Verschlüsseln fehlgeschlagen. Überprüfen Sie Ablaufdatum und Widerrufstatus der PGP-Schlüssel mithilfe eines externen Programms.</string>
   <string name="password_creation_no_keys_provided_message">Keine passenden PGP-Schlüssel gefunden.</string>
   <string name="password_creation_duplicate_error">Datei existiert bereits, bitte verwenden Sie einen anderen Dateinamen.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -49,7 +49,6 @@
   <!-- PGPHandler -->
   <string name="clipboard_copied_text">Copiado al portapapeles</string>
   <string name="file_toast_text">Proporcione un nombre de archivo</string>
-  <string name="path_toast_text">Proporcione una ruta de archivo</string>
   <string name="empty_toast_text">No puede usar una contraseña vacía o contenido adicional vacío</string>
 
   <!-- Git Async Task -->
@@ -296,7 +295,6 @@
 
   <!-- Password creation failure -->
   <string name="password_creation_file_write_fail_message">No se pudo escribir el archivo de contraseña en el almacén, inténtelo de nuevo.</string>
-  <string name="password_creation_file_delete_fail_message">No se pudo eliminar el archivo de contraseña %1$s del almacén, elimínelo manualmente.</string>
   <string name="password_creation_duplicate_error">El archivo ya existe, por favor use un nombre diferente</string>
   <string name="add_otp">Agregar TOTP</string>
   <string name="otp_import_success">Configuración de TOTP importada correctamente</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -39,7 +39,6 @@
   <!-- PGPHandler -->
   <string name="clipboard_copied_text">Copié dans le presse-papiers</string>
   <string name="file_toast_text">Veuillez fournir un nom de fichier</string>
-  <string name="path_toast_text">Veuillez fournir un chemin d\'accès au fichier</string>
   <string name="empty_toast_text">Vous ne pouvez pas utiliser un mot de passe vide ou des données supplémentaires vide</string>
   <!-- Git Async Task -->
   <string name="jgit_error_dialog_title">Une erreur c\'est produite lors d\'une opération Git</string>
@@ -247,7 +246,6 @@
   <string name="preference_custom_public_suffixes_hint">societe.com\npersonnel.com</string>
   <!-- Password creation failure -->
   <string name="password_creation_file_write_fail_message">Impossible d\'écrire le fichier de mot de passe dans le magasin, veuillez réessayer.</string>
-  <string name="password_creation_file_delete_fail_message">Impossible de supprimer le fichier de mot de passe %1$s du magasin, veuillez le supprimer manuellement.</string>
   <string name="password_creation_duplicate_error">Le fichier existe déjà, veuillez utiliser un autre nom</string>
   <string name="add_otp">Ajouter OTP</string>
   <string name="otp_import_success">Configuration TOTP importée avec succès</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -40,7 +40,6 @@
   <!-- PGPHandler -->
   <string name="clipboard_copied_text">Copiado ao portapapeis</string>
   <string name="file_toast_text">Debes proporcionar un nome de ficheiro</string>
-  <string name="path_toast_text">Por favor indica a ruta ao ficheiro</string>
   <string name="empty_toast_text">Non podes deixar baleiro o contrasinal ou o contido extra</string>
   <!-- Git Async Task -->
   <string name="jgit_error_dialog_title">Algo fallou na operación de Git</string>
@@ -255,7 +254,6 @@ a app desde unha fonte de confianza, como a Play Store, Amazon Appstore, F-Droid
   <string name="preference_custom_public_suffixes_hint">empresa.com\npersoal.com</string>
   <!-- Password creation failure -->
   <string name="password_creation_file_write_fail_message">Fallo ó escribir o ficheiro de contrasinal no almacén, inténtao outra vez.</string>
-  <string name="password_creation_file_delete_fail_message">Fallou a eliminación do ficheiro de contrasinal %1$s no almacén, intenta eliminalo manualmente.</string>
   <string name="password_creation_duplicate_error">Xa existe o ficheiro, usa un nome diferente</string>
   <string name="add_otp">Engade OTP</string>
   <string name="otp_import_success">Importouse correctamente a configuración TOTP</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -39,7 +39,6 @@
   <!-- PGPHandler -->
   <string name="clipboard_copied_text">Copiato negli appunti</string>
   <string name="file_toast_text">Sei pregato di fornire il nome di un file</string>
-  <string name="path_toast_text">Sei pregato di fornire il percorso di un file</string>
   <string name="empty_toast_text">Non puoi usare una password vuota o dei contenuti extra vuoti</string>
   <!-- Git Async Task -->
   <string name="jgit_error_dialog_title">Si è verificato un errore durante un operazione di Git</string>
@@ -242,7 +241,6 @@
   <string name="preference_custom_public_suffixes_hint">company.com\npersonal.com</string>
   <!-- Password creation failure -->
   <string name="password_creation_file_write_fail_message">Impossibile scrivere il file delle password al negozio, sei pregato di riprovare.</string>
-  <string name="password_creation_file_delete_fail_message">Impossibile eliminare il file della password %1$s dal negozio, sei pregato di eliminarlo manualmente.</string>
   <string name="password_creation_duplicate_error">Il file esiste già, sei pregato di usare un nome differente</string>
   <string name="add_otp">Aggiungi OTP</string>
   <string name="otp_import_success">Configurazione TOTP importata correttamente</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -38,7 +38,6 @@
   <!-- PGPHandler -->
   <string name="clipboard_copied_text">클립보드로 복사됨</string>
   <string name="file_toast_text">파일 이름이 필요합니다</string>
-  <string name="path_toast_text">파일 경로가 필요합니다</string>
   <string name="empty_toast_text">비어있는 비밀번호나 추가 정보를 사용할 수 없습니다</string>
   <!-- Git Async Task -->
   <string name="jgit_error_dialog_title">Git 동작 중 문제가 발생하였습니다</string>
@@ -254,7 +253,6 @@ username@example.com:…</string>
   <string name="preference_custom_public_suffixes_hint">company.com\npersonal.com</string>
   <!-- Password creation failure -->
   <string name="password_creation_file_write_fail_message">스토어에 비밀번호 파일을 작성하지 못했습니다. 다시 시도해 주세요.</string>
-  <string name="password_creation_file_delete_fail_message">스토어에서 비밀번호 파일 %1$s를 삭제하지 못했습니다. 수동으로 삭제하세요.</string>
   <string name="password_creation_duplicate_error">파일이 이미 존재합니다. 다른 이름을 사용하세요</string>
   <string name="add_otp">OTP 추가</string>
   <string name="otp_import_success">TOTP 구성을 성공적으로 가져왔습니다</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -38,7 +38,6 @@
   <!-- PGPHandler -->
   <string name="clipboard_copied_text">Skopiowano do schowka</string>
   <string name="file_toast_text">Podaj nazwę pliku</string>
-  <string name="path_toast_text">Podaj ścieżkę do pliku</string>
   <string name="empty_toast_text">Nie możesz użyć pustego hasła lub pustej dodatkowej zawartości</string>
   <!-- Git Async Task -->
   <string name="jgit_error_dialog_title">Wystąpił błąd podczas operacji Git</string>
@@ -249,7 +248,6 @@
   <string name="preference_custom_public_suffixes_summary">Autouzupełnianie rozróżni subdomeny tych domen</string>
   <!-- Password creation failure -->
   <string name="password_creation_file_write_fail_message">Nie udało się zapisać pliku z hasłem do repozytorium, spróbuj ponownie.</string>
-  <string name="password_creation_file_delete_fail_message">Nie udało się usunąć pliku hasła %1$s z repozytorium, usuń go ręcznie.</string>
   <string name="password_creation_duplicate_error">Plik o tej nazwie już istnieje, użyj innej nazwy</string>
   <string name="add_otp">Dodaj OTP</string>
   <string name="otp_import_success">Pomyślnie zaimportowano konfigurację TOTP</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -40,7 +40,6 @@
   <!-- PGPHandler -->
   <string name="clipboard_copied_text">Copiado para a área de transferência</string>
   <string name="file_toast_text">Por favor, informe um nome de arquivo</string>
-  <string name="path_toast_text">Por favor, forneça o caminho do arquivo</string>
   <string name="empty_toast_text">Você não pode usar uma senha vazia ou conteúdo extra vazio</string>
   <!-- Git Async Task -->
   <string name="jgit_error_dialog_title">Ocorreu um erro durante uma operação do Git</string>
@@ -253,7 +252,6 @@
   <string name="preference_custom_public_suffixes_hint">company.com\npersonal.com</string>
   <!-- Password creation failure -->
   <string name="password_creation_file_write_fail_message">Falha ao armazenar o arquivo de senha. Por favor, tente novamente.</string>
-  <string name="password_creation_file_delete_fail_message">Falha ao excluir o arquivo de senha %1$s da loja. Por favor, apague-o manualmente.</string>
   <string name="password_creation_duplicate_error">O arquivo já existe, por favor use um nome diferente</string>
   <string name="add_otp">Adicionar OTP</string>
   <string name="otp_import_success">Configuração TOTP importada com sucesso</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -44,7 +44,6 @@
   <!-- PGPHandler -->
   <string name="clipboard_copied_text">Скопировано в буфер обмена</string>
   <string name="file_toast_text">Пожалуйста, укажите имя файла</string>
-  <string name="path_toast_text">Пожалуйста, задайте путь к файлу</string>
   <string name="empty_toast_text">Вы не можете использовать пустой пароль или пустое поле информации</string>
   <!-- Git Async Task -->
   <string name="jgit_error_dialog_title">Произошла ошибка выполнения операции Git</string>
@@ -251,7 +250,6 @@
   <string name="preference_custom_public_suffixes_hint">company.com\npersonal.com</string>
   <!-- Password creation failure -->
   <string name="password_creation_file_write_fail_message">Не удалось записать файл пароля в хранилище, пожалуйста, повторите попытку.</string>
-  <string name="password_creation_file_delete_fail_message">Не удалось удалить файл пароля %1$s из хранилища, пожалуйста, удалите его вручную.</string>
   <string name="password_creation_duplicate_error">Файл с таким названием уже существует! Используйте другое имя</string>
   <string name="add_otp">Добавить OTP</string>
   <string name="otp_import_success">Конфигурация TOTP успешно импортирована</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -48,7 +48,6 @@
   <!-- PGPHandler -->
   <string name="clipboard_copied_text">Panoya kopyalandı</string>
   <string name="file_toast_text">Lütfen bir dosya adı belirtin</string>
-  <string name="path_toast_text">Lütfen bir dosya yolu belirtin</string>
   <string name="empty_toast_text">Boş bir şifre veya boş ekstra içerik kullanamazsınız</string>
 
   <!-- Git Async Task -->
@@ -291,7 +290,6 @@
 
   <!-- Password creation failure -->
   <string name="password_creation_file_write_fail_message">Şifre dosyası depoya yazılamadı, lütfen tekrar deneyin.</string>
-  <string name="password_creation_file_delete_fail_message">%1$s şifre dosyası depodan silinemedi, lütfen manuel olarak silin.</string>
   <string name="password_creation_duplicate_error">Dosya zaten mevcut, lütfen farklı bir ad kullanın</string>
   <string name="add_otp">OTP ekle</string>
   <string name="otp_import_success">TOTP yapılandırması başarıyla içe aktarıldı</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -39,7 +39,6 @@
   <!-- PGPHandler -->
   <string name="clipboard_copied_text">复制到剪切板</string>
   <string name="file_toast_text">请提供文件名</string>
-  <string name="path_toast_text">请提供文件路径</string>
   <string name="empty_toast_text">您不能使用空密码或空额外内容</string>
   <!-- Git Async Task -->
   <string name="jgit_error_dialog_title">Git操作过程中发生错误</string>
@@ -257,7 +256,6 @@
 personal.com</string>
   <!-- Password creation failure -->
   <string name="password_creation_file_write_fail_message">将密码文件写入存储失败,请重试</string>
-  <string name="password_creation_file_delete_fail_message">从仓库删除密码文件%1$s失败,请手动删除</string>
   <string name="password_creation_duplicate_error">文件已存在,请使用其他名称</string>
   <string name="add_otp">添加 OTP</string>
   <string name="otp_import_success">导入TOTP配置成功</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,7 +49,6 @@
   <!-- PGPHandler -->
   <string name="clipboard_copied_text">Copied to clipboard.</string>
   <string name="file_toast_text">Please provide a file name.</string>
-  <string name="path_toast_text">Please provide a file path.</string>
   <string name="empty_toast_text">You need to fill in at least a password or some extra content.</string>
 
   <!-- Git Async Task -->
@@ -328,7 +327,6 @@
   <string name="password_creation_file_encryption_failed_ids_message">\n\nEncryption failed for%1$s</string>
   <string name="password_creation_file_encryption_failed_expired_key">expired key</string>
   <string name="password_creation_file_write_fail_message">Failed to write password file to the store, please try again.</string>
-  <string name="password_creation_file_delete_fail_message">Failed to delete password file %1$s from the store, please delete it manually.</string>
   <string name="password_creation_unusable_encryption_key_error_message">Encryption failure. Check expiration date and revocation status of the PGP key(s) using an external utility.</string>
   <string name="password_creation_no_keys_provided_message">No matching PGP keys found.</string>
   <string name="password_creation_duplicate_error">File already exists, please use a different name.</string>


### PR DESCRIPTION
when editing a password entry and changing its path in the Store, an existing file at the destination is no longer silently overwritten