### PR TITLE
fix: normalize Conscrypt EdDSA keys for SSHJ host key verification

### DIFF
--- a/app/src/main/java/app/passwordstore/util/git/sshj/SshKey.kt
+++ b/app/src/main/java/app/passwordstore/util/git/sshj/SshKey.kt
@@ -35,6 +35,7 @@ import java.security.KeyPairGenerator
 import java.security.KeyStore
 import java.security.PrivateKey
 import java.security.PublicKey
+import java.security.spec.X509EncodedKeySpec
 import javax.crypto.SecretKey
 import javax.crypto.SecretKeyFactory
 import logcat.asLog
@@ -42,6 +43,7 @@ import logcat.logcat
 import net.schmizz.sshj.SSHClient
 import net.schmizz.sshj.common.Buffer
 import net.schmizz.sshj.common.KeyType
+import net.schmizz.sshj.common.SSHRuntimeException
 import net.schmizz.sshj.userauth.keyprovider.KeyProvider
 import net.schmizz.sshj.userauth.password.PasswordFinder
 
@@ -64,9 +66,39 @@ fun parseSshPublicKey(sshPublicKey: String): PublicKey? {
   return Buffer.PlainBuffer(Base64.decode(sshKeyParts[1], Base64.NO_WRAP)).readPublicKey()
 }
 
+internal fun normalizeForSshj(key: PublicKey): PublicKey {
+  if (KeyType.fromKey(key) != KeyType.UNKNOWN) return key
+
+  val encoded =
+    key.encoded
+      ?: throw SSHRuntimeException(
+        "Cannot normalize key: encoded form is null (${key.javaClass.name})"
+      )
+
+  val bcAlgorithm =
+    when (key.algorithm) {
+      "EdDSA",
+      "Ed25519",
+      "1.3.101.112" -> "Ed25519"
+      "Ed448",
+      "1.3.101.113" -> "Ed448"
+      else -> key.algorithm
+    }
+
+  return try {
+    KeyFactory.getInstance(bcAlgorithm, "BC").generatePublic(X509EncodedKeySpec(encoded))
+  } catch (e: Exception) {
+    throw SSHRuntimeException(
+      "Cannot normalize ${key.javaClass.name} (algorithm=${key.algorithm}) for SSHJ",
+      e,
+    )
+  }
+}
+
 fun toSshPublicKey(publicKey: PublicKey): String {
-  val rawPublicKey = Buffer.PlainBuffer().putPublicKey(publicKey).compactData
-  val keyType = KeyType.fromKey(publicKey)
+  val normalizedKey = normalizeForSshj(publicKey)
+  val rawPublicKey = Buffer.PlainBuffer().putPublicKey(normalizedKey).compactData
+  val keyType = KeyType.fromKey(normalizedKey)
   return "$keyType ${Base64.encodeToString(rawPublicKey, Base64.NO_WRAP)}"
 }
 

--- a/app/src/main/java/app/passwordstore/util/git/sshj/SshjSessionFactory.kt
+++ b/app/src/main/java/app/passwordstore/util/git/sshj/SshjSessionFactory.kt
@@ -90,12 +90,13 @@ private fun makeTofuHostKeyVerifier(
   if (!hostKeyFile.exists()) {
     return object : HostKeyVerifier {
       override fun verify(hostname: String?, port: Int, key: PublicKey?): Boolean {
+        val normalizedKey = key?.let { normalizeForSshj(it) }
         val digest =
           runCatching { SecurityUtils.getMessageDigest("SHA-256") }
             .getOrElse { e -> throw SSHRuntimeException(e) }
-        digest.update(PlainBuffer().putPublicKey(key).compactData)
+        digest.update(PlainBuffer().putPublicKey(normalizedKey).compactData)
         val digestData = digest.digest()
-        val keyType = KeyType.fromKey(key)
+        val keyType = KeyType.fromKey(normalizedKey)
         val hostKeyEntry = "SHA256:${Base64.encodeToString(digestData, Base64.NO_WRAP)}"
         val hostKeyEntryNoPadding =
           "SHA256:${Base64.encodeToString(digestData, Base64.NO_WRAP or Base64.NO_PADDING)}"
@@ -140,7 +141,16 @@ private fun makeTofuHostKeyVerifier(
   } else {
     val hostKeyEntry = hostKeyFile.readText()
     logcat(SshjSessionFactory::class.java.simpleName) { "Pinned host key: $hostKeyEntry" }
-    return FingerprintVerifier.getInstance(hostKeyEntry)
+    val delegate = FingerprintVerifier.getInstance(hostKeyEntry)
+    return object : HostKeyVerifier {
+      override fun verify(hostname: String?, port: Int, key: PublicKey?): Boolean {
+        return delegate.verify(hostname, port, key?.let { normalizeForSshj(it) })
+      }
+
+      override fun findExistingAlgorithms(hostname: String?, port: Int): MutableList<String> {
+        return delegate.findExistingAlgorithms(hostname, port)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- On Android 13+, SSH connections fail with **"Don't know how to encode key: com.android.org.conscrypt.OpenSslEdDsaPublicKey"** when the server presents an Ed25519 host key
- Android's Conscrypt provider deserializes the server's Ed25519 host key as `OpenSslEdDsaPublicKey`, which SSHJ does not recognize — this crashes during host key verification **before the user's own key is even used**, so it affects all key types (imported, keystore-native, PGP)
- Added `normalizeForSshj()` which re-encodes unrecognized `PublicKey` instances through BouncyCastle's `KeyFactory` using their X.509 encoding, producing a key class SSHJ can handle
- Applied normalization at three sites:
  - TOFU host key verification (`SshjSessionFactory.kt` — first connection dialog)
  - Pinned host key verification (`SshjSessionFactory.kt` — wrapped `FingerprintVerifier`)
  - Public key serialization (`SshKey.kt` — `toSshPublicKey()`)

## Root Cause

`SshjConfig.setUpBouncyCastleForSshj()` inserts BouncyCastle at JCE provider position 1, but on Android 13+ Conscrypt handles Ed25519 natively. During SSH key exchange, the server's host key gets deserialized as `com.android.org.conscrypt.OpenSslEdDsaPublicKey`. SSHJ's `KeyType.fromKey()` and `Buffer.PlainBuffer.putPublicKey()` only recognize BouncyCastle/i2p EdDSA key classes, so they fail with "Don't know how to encode key."

The fix short-circuits for keys SSHJ already recognizes (`KeyType.fromKey(key) != KeyType.UNKNOWN`), so existing behavior is unchanged for RSA/ECDSA keys.

## Test plan

- [ ] Build: `./gradlew assembleDebug`
- [ ] Test on Android 13+ device connecting to a server with Ed25519 host key (e.g., GitHub)
- [ ] Verify first-connection TOFU dialog appears and works
- [ ] Verify subsequent connections with pinned host key succeed
- [ ] Verify with both KeystoreNative (RSA/ECDSA) and imported SSH keys
- [ ] Verify on older Android versions (pre-13) to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)