### PR TITLE
fix: normalize Conscrypt EdDSA keys for SSHJ host key verification

### DIFF
--- a/app/src/main/java/app/passwordstore/util/git/sshj/SshKey.kt
+++ b/app/src/main/java/app/passwordstore/util/git/sshj/SshKey.kt
@@ -35,6 +35,7 @@ import java.security.KeyPairGenerator
 import java.security.KeyStore
 import java.security.PrivateKey
 import java.security.PublicKey
+import java.security.spec.X509EncodedKeySpec
 import javax.crypto.SecretKey
 import javax.crypto.SecretKeyFactory
 import logcat.asLog
@@ -42,6 +43,7 @@ import logcat.logcat
 import net.schmizz.sshj.SSHClient
 import net.schmizz.sshj.common.Buffer
 import net.schmizz.sshj.common.KeyType
+import net.schmizz.sshj.common.SSHRuntimeException
 import net.schmizz.sshj.userauth.keyprovider.KeyProvider
 import net.schmizz.sshj.userauth.password.PasswordFinder
 
@@ -64,9 +66,41 @@ fun parseSshPublicKey(sshPublicKey: String): PublicKey? {
   return Buffer.PlainBuffer(Base64.decode(sshKeyParts[1], Base64.NO_WRAP)).readPublicKey()
 }
 
+internal fun normalizeForSshj(key: PublicKey): PublicKey {
+  if (KeyType.fromKey(key) != KeyType.UNKNOWN) return key
+
+  val encoded =
+    key.encoded
+      ?: throw SSHRuntimeException(
+        "Cannot normalize key: encoded form is null (${key.javaClass.name})"
+      )
+
+  val bcAlgorithm =
+    when (key.algorithm) {
+      "EdDSA",
+      "Ed25519",
+      "1.3.101.112" -> "Ed25519"
+      "Ed448",
+      "1.3.101.113" -> "Ed448"
+      else -> key.algorithm
+    }
+
+  return runCatching {
+      KeyFactory.getInstance(bcAlgorithm, "BC").generatePublic(X509EncodedKeySpec(encoded))
+    }
+    .getOrElse { error ->
+      logcat("normalizeForSshj") { error.asLog() }
+      throw SSHRuntimeException(
+        "Cannot normalize ${key.javaClass.name} (algorithm=${key.algorithm}) for SSHJ",
+        error,
+      )
+    }
+}
+
 fun toSshPublicKey(publicKey: PublicKey): String {
-  val rawPublicKey = Buffer.PlainBuffer().putPublicKey(publicKey).compactData
-  val keyType = KeyType.fromKey(publicKey)
+  val normalizedKey = normalizeForSshj(publicKey)
+  val rawPublicKey = Buffer.PlainBuffer().putPublicKey(normalizedKey).compactData
+  val keyType = KeyType.fromKey(normalizedKey)
   return "$keyType ${Base64.encodeToString(rawPublicKey, Base64.NO_WRAP)}"
 }
 

--- a/app/src/main/java/app/passwordstore/util/git/sshj/SshjConfig.kt
+++ b/app/src/main/java/app/passwordstore/util/git/sshj/SshjConfig.kt
@@ -33,28 +33,32 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.slf4j.Logger
 
 fun setUpBouncyCastleForSshj() {
-  // Enforce Java (instead of Android provided) BouncyCastle as security provider and move
-  // it to the top position
-  // Note: This may affect crypto operations in other parts of the application.
+  /**
+   * Replace the Android BC provider with the Java BouncyCastle provider since the former does not
+   * include all the required algorithms. Note: This may affect crypto operations in other parts of
+   * the application.
+   */
   val bcIndex =
     Security.getProviders().indexOfFirst { it.name == BouncyCastleProvider.PROVIDER_NAME }
-  if (bcIndex != -1) {
-    // Remove Android or Java BC
-    Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
-  }
-  // May be needed on Android Pie+ as per https://stackoverflow.com/a/57897224/297261
-  runCatching { Class.forName("sun.security.jca.Providers") }
-  // Insert Java BC at the top position (index is 1-based)
-  Security.insertProviderAt(BouncyCastleProvider(), 1)
 
-  if (SshKey.type == SshKey.Type.KeystoreNative) {
-    SecurityUtils.setRegisterBouncyCastle(false)
-    SecurityUtils.setSecurityProvider(null)
+  if (bcIndex == -1) {
+    // No Android BC found, install Java BC at lowest priority.
+    Security.addProvider(BouncyCastleProvider())
+  } else {
+    // Replace Android BC with Java BC, inserted at the same position.
+    Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
+    // May be needed on Android Pie+ as per https://stackoverflow.com/a/57897224/297261
+    runCatching { Class.forName("sun.security.jca.Providers") }
+    Security.insertProviderAt(BouncyCastleProvider(), bcIndex + 1) // method wants 1-based idx
   }
 
   logcat("setUpBouncyCastleForSshj") {
     "JCE providers: ${Security.getProviders().joinToString { "${it.name} (${it.version})" }}"
   }
+
+  // Prevent sshj from forwarding all cryptographic operations to BC
+  SecurityUtils.setRegisterBouncyCastle(false)
+  SecurityUtils.setSecurityProvider(null)
 }
 
 private object LogcatLoggerFactory : LoggerFactory {

--- a/app/src/main/java/app/passwordstore/util/git/sshj/SshjSessionFactory.kt
+++ b/app/src/main/java/app/passwordstore/util/git/sshj/SshjSessionFactory.kt
@@ -90,12 +90,13 @@ private fun makeTofuHostKeyVerifier(
   if (!hostKeyFile.exists()) {
     return object : HostKeyVerifier {
       override fun verify(hostname: String?, port: Int, key: PublicKey?): Boolean {
+        val normalizedKey = key?.let { normalizeForSshj(it) }
         val digest =
           runCatching { SecurityUtils.getMessageDigest("SHA-256") }
             .getOrElse { e -> throw SSHRuntimeException(e) }
-        digest.update(PlainBuffer().putPublicKey(key).compactData)
+        digest.update(PlainBuffer().putPublicKey(normalizedKey).compactData)
         val digestData = digest.digest()
-        val keyType = KeyType.fromKey(key)
+        val keyType = KeyType.fromKey(normalizedKey)
         val hostKeyEntry = "SHA256:${Base64.encodeToString(digestData, Base64.NO_WRAP)}"
         val hostKeyEntryNoPadding =
           "SHA256:${Base64.encodeToString(digestData, Base64.NO_WRAP or Base64.NO_PADDING)}"
@@ -140,7 +141,16 @@ private fun makeTofuHostKeyVerifier(
   } else {
     val hostKeyEntry = hostKeyFile.readText()
     logcat(SshjSessionFactory::class.java.simpleName) { "Pinned host key: $hostKeyEntry" }
-    return FingerprintVerifier.getInstance(hostKeyEntry)
+    val delegate = FingerprintVerifier.getInstance(hostKeyEntry)
+    return object : HostKeyVerifier {
+      override fun verify(hostname: String?, port: Int, key: PublicKey?): Boolean {
+        return delegate.verify(hostname, port, key?.let { normalizeForSshj(it) })
+      }
+
+      override fun findExistingAlgorithms(hostname: String?, port: Int): MutableList<String> {
+        return delegate.findExistingAlgorithms(hostname, port)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
On Android 13+, SSH servers presenting Ed25519 host keys trigger "Don't know how to encode key: com.android.org.conscrypt.OpenSslEdDsaPublicKey" because SSHJ does not recognize Conscrypt's EdDSA key class.

Re-encode unrecognized public keys through BouncyCastle's KeyFactory so SSHJ can handle them. Applied to both TOFU and pinned host key verification paths, and to toSshPublicKey() for key serialization.

reverting workaround (9d9eaaa) that fixed sshj failure

Applies PR #865 with modifications and may therefore close  #865.