### PR TITLE
import all keys from a multi-key .asc file in PGP Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file
 ### Fixed
 
 - Accidental overwriting of existing password items of same file name after editing
+- PGP Manager imports all keys from an `.asc` file containing multiple key blocks (previously only the first key was imported)
 
 ## [1.16.3] - 2026-04-15
 

--- a/app/src/main/java/app/passwordstore/ui/pgp/PGPKeyImportActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/pgp/PGPKeyImportActivity.kt
@@ -14,7 +14,9 @@ import androidx.fragment.app.setFragmentResultListener
 import androidx.lifecycle.lifecycleScope
 import app.passwordstore.R
 import app.passwordstore.crypto.KeyUtils.isCertificateOrKey
+import app.passwordstore.crypto.KeyUtils.parseAllCertificatesOrKeys
 import app.passwordstore.crypto.KeyUtils.tryGetKeyId
+import app.passwordstore.crypto.PGPIdentifier
 import app.passwordstore.crypto.PGPKey
 import app.passwordstore.crypto.PGPKeyManager
 import app.passwordstore.crypto.errors.KeyAlreadyExistsException
@@ -42,17 +44,19 @@ import logcat.logcat
 @AndroidEntryPoint
 class PGPKeyImportActivity : AppCompatActivity() {
 
-  /**
-   * A [ByteArray] containing the contents of the previously selected file. This is necessary for
-   * the replacement case where we do not want users to have to pick the file again.
-   */
-  private var lastBytes: ByteArray? = null
   @Inject lateinit var pgpKeyManager: PGPKeyManager
   @Inject lateinit var repository: CryptoRepository
   @Inject lateinit var dispatcherProvider: DispatcherProvider
 
   private val MAX_RETRIES = 3
   private var retries = 0
+
+  /** Keys parsed from the picked file that are still waiting to be processed. */
+  private val pendingImports = mutableListOf<PGPKey>()
+  /** [PGPIdentifier.KeyId]s of keys that were successfully stored. */
+  private val importedKeyIds = mutableListOf<PGPIdentifier.KeyId>()
+  /** Keys that ultimately failed to import along with the reason. */
+  private val importFailures = mutableListOf<Pair<PGPKey, Throwable>>()
 
   private val pgpKeyImportAction =
     registerForActivityResult(GetContent()) { uri ->
@@ -66,7 +70,7 @@ class PGPKeyImportActivity : AppCompatActivity() {
             ?: throw IllegalStateException("Failed to open selected file")
         val bytes = keyInputStream.use { `is` -> `is`.readBytes() }
         if (isCertificateOrKey(PGPKey(bytes))) {
-          runCatching { importKey(bytes, false) }.run(::handleImportResult)
+          importAllKeys(bytes)
         } else {
           // incoming material may be a symmetrically encrypted key backup
           lifecycleScope.launch(dispatcherProvider.main()) { askBackupCode(bytes, isError = false) }
@@ -83,19 +87,72 @@ class PGPKeyImportActivity : AppCompatActivity() {
       }
   }
 
-  override fun onDestroy() {
-    lastBytes = null
-    super.onDestroy()
+  /**
+   * Splits [bytes] into one [PGPKey] per certificate/key block found and processes them
+   * sequentially. A multi-key armored file (e.g. produced by `gpg --export A B C`) yields several
+   * blocks; each is imported via [pgpKeyManager] independently, so partial failures
+   * (already-exists, unusable) are reported per key without aborting the rest.
+   */
+  private fun importAllKeys(bytes: ByteArray) {
+    pendingImports.clear()
+    importedKeyIds.clear()
+    importFailures.clear()
+    parseAllCertificatesOrKeys(PGPKey(bytes)).forEach {
+      pendingImports.add(PGPKey(it.toAsciiArmoredString().toByteArray()))
+    }
+    processNextImport()
   }
 
-  private fun importKey(bytes: ByteArray, replace: Boolean): PGPKey? {
-    lastBytes = bytes
-    val (key, error) = pgpKeyManager.addKey(PGPKey(bytes), replace = replace)
-    if (replace) {
-      lastBytes = null
+  private fun processNextImport() {
+    if (pendingImports.isEmpty()) {
+      showImportSummary()
+      return
     }
+    val key = pendingImports.removeAt(0)
+    val result = runCatching { addKeyOrThrow(key, replace = false) }
+    handleSingleImportResult(result, key)
+  }
+
+  private fun handleSingleImportResult(result: Result<PGPKey?, Throwable>, sourceKey: PGPKey) {
+    if (result.isOk) {
+      result.get()?.let { tryGetKeyId(it)?.let(importedKeyIds::add) }
+      processNextImport()
+      return
+    }
+    val error = result.getError()
+    if (error is KeyAlreadyExistsException) {
+      val keyId = tryGetKeyId(sourceKey)
+      MaterialAlertDialogBuilder(this)
+        .setTitle(getString(R.string.pgp_key_import_failed))
+        .setMessage(
+          getString(R.string.pgp_key_import_failed_replace_message) +
+            if (keyId != null) "\n\n$keyId" else ""
+        )
+        .setPositiveButton(R.string.dialog_yes) { _, _ ->
+          val retry = runCatching { addKeyOrThrow(sourceKey, replace = true) }
+          if (retry.isOk) {
+            retry.get()?.let { tryGetKeyId(it)?.let(importedKeyIds::add) }
+          } else {
+            importFailures.add(sourceKey to (retry.getError() ?: error))
+          }
+          processNextImport()
+        }
+        .setNegativeButton(R.string.dialog_no) { _, _ ->
+          importFailures.add(sourceKey to error)
+          processNextImport()
+        }
+        .setCancelable(false)
+        .show()
+    } else {
+      importFailures.add(sourceKey to (error ?: NullPointerException()))
+      processNextImport()
+    }
+  }
+
+  private fun addKeyOrThrow(key: PGPKey, replace: Boolean): PGPKey? {
+    val (stored, error) = pgpKeyManager.addKey(key, replace = replace)
     if (error != null) throw error
-    return key
+    return stored
   }
 
   private suspend fun askBackupCode(bytes: ByteArray, isError: Boolean) {
@@ -122,58 +179,79 @@ class PGPKeyImportActivity : AppCompatActivity() {
     val result = repository.decryptSym(backupCode, message, outputStream)
     if (result.isOk) {
       val decryptedBytes = result.getOrThrow().toByteArray()
-      runCatching { importKey(decryptedBytes, false) }.run(::handleImportResult)
+      importAllKeys(decryptedBytes)
     } else {
       result.getError()?.let { logcat { it.asLog() } }
       askBackupCode(bytes, isError = true) // retry
     }
   }
 
-  private fun handleImportResult(result: Result<PGPKey?, Throwable>) {
-    if (result.isOk) {
-      val key = result.get()
-      if (key == null) {
-        setResult(RESULT_CANCELED)
-        finish()
-        /* This return convinces Kotlin that the control flow for `key == null` definitely
-        terminates here and allows for a smart cast below. */
-        return
-      }
-      val keyId = tryGetKeyId(key)
-      MaterialAlertDialogBuilder(this)
-        .setTitle(getString(R.string.pgp_key_import_succeeded))
-        .setMessage(getString(R.string.pgp_key_import_succeeded_message, keyId))
-        .setPositiveButton(android.R.string.ok) { _, _ ->
-          setResult(RESULT_OK, Intent().putExtra("PGP_KEY_ID", keyId?.id ?: 0L))
-          finish()
-        }
-        .setCancelable(false)
-        .show()
-    } else {
-      val dialog =
-        MaterialAlertDialogBuilder(this)
-          .setTitle(getString(R.string.pgp_key_import_failed))
-          .setCancelable(false)
-
-      val error = result.getError()
-      if (error is KeyAlreadyExistsException && lastBytes != null) {
-        dialog
-          .setMessage(getString(R.string.pgp_key_import_failed_replace_message))
-          .setPositiveButton(R.string.dialog_yes) { _, _ ->
-            handleImportResult(
-              runCatching { importKey(lastBytes ?: throw NullPointerException(), replace = true) }
-            )
-          }
-          .setNegativeButton(R.string.dialog_no) { _, _ -> finish() }
-      } else {
-        val errMessage =
-          if (error is UnusableKeyException) {
-            getString(R.string.pgp_key_import_failed_unusable_message)
-          } else error?.message
-        dialog.setMessage(errMessage).setPositiveButton(android.R.string.ok) { _, _ -> finish() }
-      }
-
-      dialog.show()
+  private fun showImportSummary() {
+    if (importedKeyIds.isEmpty() && importFailures.isEmpty()) {
+      setResult(RESULT_CANCELED)
+      finish()
+      return
     }
+    val builder = MaterialAlertDialogBuilder(this).setCancelable(false)
+    when {
+      importFailures.isEmpty() && importedKeyIds.size == 1 -> {
+        val keyId = importedKeyIds.first()
+        builder
+          .setTitle(getString(R.string.pgp_key_import_succeeded))
+          .setMessage(getString(R.string.pgp_key_import_succeeded_message, keyId))
+      }
+      importFailures.isEmpty() -> {
+        builder
+          .setTitle(
+            resources.getQuantityString(
+              R.plurals.pgp_key_import_succeeded_multi_title,
+              importedKeyIds.size,
+              importedKeyIds.size,
+            )
+          )
+          .setMessage(
+            getString(
+              R.string.pgp_key_import_succeeded_multi_message,
+              importedKeyIds.joinToString("\n"),
+            )
+          )
+      }
+      else -> {
+        val failuresText =
+          importFailures.joinToString("\n") { (k, e) ->
+            val id = tryGetKeyId(k)?.toString() ?: "?"
+            val reason =
+              when (e) {
+                is KeyAlreadyExistsException -> getString(R.string.pgp_key_import_failed)
+                is UnusableKeyException ->
+                  getString(R.string.pgp_key_import_failed_unusable_message)
+                else -> e.message ?: e::class.simpleName ?: "error"
+              }
+            "$id: $reason"
+          }
+        val titleRes =
+          if (importedKeyIds.isEmpty()) R.string.pgp_key_import_failed
+          else R.string.pgp_key_import_succeeded
+        builder
+          .setTitle(getString(titleRes))
+          .setMessage(
+            getString(
+              R.string.pgp_key_import_partial_failure_message,
+              importedKeyIds.size,
+              failuresText,
+            )
+          )
+      }
+    }
+    builder
+      .setPositiveButton(android.R.string.ok) { _, _ ->
+        if (importedKeyIds.isNotEmpty()) {
+          setResult(RESULT_OK, Intent().putExtra("PGP_KEY_ID", importedKeyIds.first().id))
+        } else {
+          setResult(RESULT_CANCELED)
+        }
+        finish()
+      }
+      .show()
   }
 }

--- a/app/src/main/java/app/passwordstore/ui/pgp/PGPKeyImportActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/pgp/PGPKeyImportActivity.kt
@@ -231,7 +231,7 @@ class PGPKeyImportActivity : AppCompatActivity() {
           }
         val titleRes =
           if (importedKeyIds.isEmpty()) R.string.pgp_key_import_failed
-          else R.string.pgp_key_import_succeeded
+          else R.string.pgp_key_import_partial
         builder
           .setTitle(getString(titleRes))
           .setMessage(

--- a/app/src/main/java/app/passwordstore/ui/pgp/PGPKeyImportActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/pgp/PGPKeyImportActivity.kt
@@ -222,7 +222,7 @@ class PGPKeyImportActivity : AppCompatActivity() {
             val id = tryGetKeyId(k)?.toString() ?: "?"
             val reason =
               when (e) {
-                is KeyAlreadyExistsException -> getString(R.string.pgp_key_import_failed)
+                is KeyAlreadyExistsException -> getString(R.string.pgp_key_import_skipped_existing)
                 is UnusableKeyException ->
                   getString(R.string.pgp_key_import_failed_unusable_message)
                 else -> e.message ?: e::class.simpleName ?: "error"

--- a/app/src/main/java/app/passwordstore/ui/pgp/PGPKeyImportActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/pgp/PGPKeyImportActivity.kt
@@ -246,7 +246,10 @@ class PGPKeyImportActivity : AppCompatActivity() {
     builder
       .setPositiveButton(android.R.string.ok) { _, _ ->
         if (importedKeyIds.isNotEmpty()) {
-          setResult(RESULT_OK, Intent().putExtra("PGP_KEY_ID", importedKeyIds.first().id))
+          setResult(
+            RESULT_OK,
+            Intent().putExtra("PGP_KEY_IDS", importedKeyIds.map { it.id }.toLongArray()),
+          )
         } else {
           setResult(RESULT_CANCELED)
         }

--- a/app/src/main/java/app/passwordstore/ui/pgp/PGPKeyListActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/pgp/PGPKeyListActivity.kt
@@ -74,9 +74,12 @@ class PGPKeyListActivity : AppCompatActivity() {
       if (it.resultCode == RESULT_OK) {
         if (isAddingKeys) keysAdded = true
         it.data?.let { data ->
-          /* If we replace a key by itself, we unregister it as an authentication key,
-           * since the replacement may come without that capability */
-          if (data.getLongExtra("PGP_KEY_ID", 0L) == SshKey.pgpLongKeyId) SshKey.delete()
+          /* If we replace a key that is currently registered for SSH auth, drop the SSH
+           * registration: the cached .ssh_key.pub is a snapshot of the previous PGP auth
+           * subkey and may no longer match the replacement (different subkey, or no auth
+           * capability at all). Forcing a re-setup avoids silent SSH auth breakage. */
+          val importedIds = data.getLongArrayExtra("PGP_KEY_IDS") ?: longArrayOf()
+          if (SshKey.pgpLongKeyId in importedIds) SshKey.delete()
         }
         viewModel.updateKeySet()
       }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -412,6 +412,7 @@
   <string name="pgp_key_import_succeeded_multi_message">The imported key IDs are listed below, please review them for correctness:\n%1$s</string>
   <string name="pgp_key_import_partial_failure_message">Imported %1$d key(s) successfully. The following keys failed to import:\n%2$s</string>
   <string name="pgp_key_import_skipped_existing">Already exists (replacement skipped)</string>
+  <string name="pgp_key_import_partial">Some PGP keys could not be imported</string>
   <string name="pgp_key_export_failed">Failed to export PGP key</string>
   <string name="pgp_key_export_succeeded">Successfully exported PGP key</string>
   <string name="pgp_full_name_hint">Full name</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -405,6 +405,12 @@
   <string name="pgp_key_import_failed_unusable_message">The given key is not usable for encryption. Please ensure that a subkey for encryption exists and that it has not expired or been revoked.</string>
   <string name="pgp_key_import_succeeded">Successfully imported PGP key</string>
   <string name="pgp_key_import_succeeded_message">The key ID of the imported key is given below, please review it for correctness:\n%1$s</string>
+  <plurals name="pgp_key_import_succeeded_multi_title">
+    <item quantity="one">Successfully imported %1$d PGP key</item>
+    <item quantity="other">Successfully imported %1$d PGP keys</item>
+  </plurals>
+  <string name="pgp_key_import_succeeded_multi_message">The imported key IDs are listed below, please review them for correctness:\n%1$s</string>
+  <string name="pgp_key_import_partial_failure_message">Imported %1$d key(s) successfully. The following keys failed to import:\n%2$s</string>
   <string name="pgp_key_export_failed">Failed to export PGP key</string>
   <string name="pgp_key_export_succeeded">Successfully exported PGP key</string>
   <string name="pgp_full_name_hint">Full name</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -411,6 +411,7 @@
   </plurals>
   <string name="pgp_key_import_succeeded_multi_message">The imported key IDs are listed below, please review them for correctness:\n%1$s</string>
   <string name="pgp_key_import_partial_failure_message">Imported %1$d key(s) successfully. The following keys failed to import:\n%2$s</string>
+  <string name="pgp_key_import_skipped_existing">Already exists (replacement skipped)</string>
   <string name="pgp_key_export_failed">Failed to export PGP key</string>
   <string name="pgp_key_export_succeeded">Successfully exported PGP key</string>
   <string name="pgp_full_name_hint">Full name</string>

--- a/crypto/pgpainless/src/main/kotlin/app/passwordstore/crypto/KeyUtils.kt
+++ b/crypto/pgpainless/src/main/kotlin/app/passwordstore/crypto/KeyUtils.kt
@@ -8,6 +8,7 @@ package app.passwordstore.crypto
 import app.passwordstore.crypto.PGPIdentifier.KeyId
 import app.passwordstore.crypto.PGPIdentifier.UserId
 import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getOr
 import com.github.michaelbull.result.runCatching
 import java.security.PublicKey
 import java.util.Date
@@ -34,6 +35,21 @@ public object KeyUtils {
         incoming.filter { it.isSecretKey() }?.firstOrNull() ?: incoming.firstOrNull()
       }
       .get()
+
+  /**
+   * Parses every PGP certificate or key block contained in [key]'s payload. A typical multi-key
+   * .asc file (e.g. produced by `gpg --export A B C`) holds several concatenated armored blocks;
+   * this helper yields one [OpenPGPCertificate] per block, with any secret keys ordered before
+   * public certificates to match the preference used by [tryParseCertificateOrKey]. Returns an
+   * empty list if parsing fails or no key is found.
+   */
+  public fun parseAllCertificatesOrKeys(key: PGPKey): List<OpenPGPCertificate> =
+    runCatching {
+        OpenPGPKeyReader().parseKeysOrCertificates(key.contents.inputStream()).sortedByDescending {
+          it.isSecretKey()
+        }
+      }
+      .getOr(emptyList())
 
   /**
    * Parses an [OpenPGPPrimaryKey] from the given [PGPKey] and calculates its long primary key ID

--- a/crypto/pgpainless/src/test/kotlin/app/passwordstore/crypto/KeyUtilsTest.kt
+++ b/crypto/pgpainless/src/test/kotlin/app/passwordstore/crypto/KeyUtilsTest.kt
@@ -7,6 +7,7 @@ package app.passwordstore.crypto
 
 import app.passwordstore.crypto.KeyUtils.isKeyUsable
 import app.passwordstore.crypto.KeyUtils.isSecretKey
+import app.passwordstore.crypto.KeyUtils.parseAllCertificatesOrKeys
 import app.passwordstore.crypto.KeyUtils.tryGetKeyId
 import app.passwordstore.crypto.KeyUtils.tryParseCertificateOrKey
 import app.passwordstore.crypto.TestUtils.AllKeys
@@ -32,6 +33,26 @@ class KeyUtilsTest {
     assertNotNull(keyId)
     assertIs<PGPIdentifier.KeyId>(keyId)
     assertEquals("b950ae2813841585", keyId.toString())
+  }
+
+  @Test
+  fun parseAllCertificatesOrKeysReturnsEveryBlockInMultiKeyArmor() {
+    val aliceBytes =
+      this::class.java.classLoader.getResource("alice_owner@example_com")!!.readBytes()
+    val bobbyBytes =
+      this::class.java.classLoader.getResource("bobby_owner@example_com")!!.readBytes()
+    val combined = aliceBytes + "\n".toByteArray() + bobbyBytes
+
+    val parsed = parseAllCertificatesOrKeys(PGPKey(combined))
+    assertEquals(2, parsed.size)
+    val ids = parsed.map { tryGetKeyId(it).toString() }.toSet()
+    assertEquals(2, ids.size, "expected two distinct key IDs but got $ids")
+  }
+
+  @Test
+  fun parseAllCertificatesOrKeysReturnsEmptyOnGarbage() {
+    val garbage = PGPKey("not a pgp key".toByteArray())
+    assertEquals(emptyList(), parseAllCertificatesOrKeys(garbage))
   }
 
   @Test

--- a/crypto/pgpainless/src/test/kotlin/app/passwordstore/crypto/PGPKeyManagerTest.kt
+++ b/crypto/pgpainless/src/test/kotlin/app/passwordstore/crypto/PGPKeyManagerTest.kt
@@ -8,6 +8,7 @@ package app.passwordstore.crypto
 // import app.passwordstore.crypto.errors.UnusableKeyException
 import app.passwordstore.crypto.CryptoConstants.KEY_PASSPHRASE
 import app.passwordstore.crypto.CryptoConstants.PLAIN_TEXT
+import app.passwordstore.crypto.KeyUtils.parseAllCertificatesOrKeys
 import app.passwordstore.crypto.KeyUtils.tryGetKeyId
 import app.passwordstore.crypto.PGPIdentifier.KeyId
 import app.passwordstore.crypto.PGPIdentifier.UserId
@@ -223,6 +224,30 @@ class PGPKeyManagerTest {
   fun replaceSecretKeyWithSecretKey() {
     assertTrue(keyManager.addKey(secretKey).isOk)
     assertTrue(keyManager.addKey(secretKey).isErr)
+  }
+
+  @Test
+  fun importIteratesMultiKeyArmor() {
+    val aliceBytes =
+      this::class.java.classLoader.getResource("alice_owner@example_com")!!.readBytes()
+    val bobbyBytes =
+      this::class.java.classLoader.getResource("bobby_owner@example_com")!!.readBytes()
+    val combined = aliceBytes + "\n".toByteArray() + bobbyBytes
+
+    val parsedCerts = parseAllCertificatesOrKeys(PGPKey(combined))
+    assertEquals(2, parsedCerts.size)
+
+    parsedCerts.forEach { cert ->
+      val perKey = PGPKey(cert.toAsciiArmoredString().toByteArray())
+      assertTrue(keyManager.addKey(perKey).isOk)
+    }
+
+    keyManager.getAllKeys().apply {
+      assertTrue(this.isOk)
+      assertEquals(2, this.unwrap().size)
+    }
+    assertTrue(keyManager.getKeyById(KeyId(-7087927403306410599)).isOk) // Alice
+    assertTrue(keyManager.getKeyById(KeyId(-961222705095032109)).isOk) // Bobby
   }
 
   @Test


### PR DESCRIPTION
> *Heads-up*: drafted with AI assistance (Claude Opus 4.7), then built, tested on a real device, and reviewed by me.

## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## :scroll: Description

Importing an `.asc` with multiple concatenated key blocks (e.g. `gpg --export A B C`) only stored the first key. No error, no log line — the rest was silently dropped.

Cause: `KeyUtils.tryParseCertificateOrKey` runs `OpenPGPKeyReader.parseKeysOrCertificates` (which already returns a `List<OpenPGPCertificate>` of every block) and then keeps `firstOrNull()`. The import path goes through that helper.

Four commits:

1. **The fix.** Adds `KeyUtils.parseAllCertificatesOrKeys` returning the full list (secrets first). `PGPKeyImportActivity` iterates each cert, re-armors it, calls `addKey` per key, and aggregates results into one summary dialog at the end. The existing per-key "Replace?" prompt is preserved. Same fan-out applied to `decryptWithBackupCode` so multi-key encrypted backups also restore in full.
2. **Summary copy.** Adds `pgp_key_import_skipped_existing` so a declined replacement reads `<keyId>: Already exists (replacement skipped)` instead of the previous `Failed to import PGP key`.
3. **Result extra.** The activity's result `Intent` now carries `PGP_KEY_IDS` (`LongArray`) instead of a single `PGP_KEY_ID` long. The lone consumer (`PGPKeyListActivity`) uses it to drop the cached SSH PGP-auth registration when its key was replaced — sending only the first ID could leave the cache stale on multi-key imports. Incidentally fixes a latent false-match when no SSH key is set (`getLongExtra(…, 0L) == pgpLongKeyId` was true by default).
4. **Partial-result title.** When a multi-key import has both successes and failures, the summary dialog now uses a dedicated `pgp_key_import_partial` title ("Some PGP keys could not be imported") instead of reusing the all-success title. A user scanning only the title no longer reads a clean success when e.g. 1 of N keys was actually rejected.

`tryParseCertificateOrKey` is intentionally left as-is. Every other caller receives `PGPKey`s loaded from `PGPKeyManager.getKeyById` / `getAllKeys`, which read one-key-per-file storage — "first only" is correct there.

## :bulb: Motivation and Context

I ran into this importing a `.asc` with several recipient public keys at once — only one ended up in the manager, no feedback. Easy footgun for anyone using `gpg --export <fpr> <fpr> <fpr>`.

## :green_heart: How did you test it?

Unit (`crypto/pgpainless`):
- `KeyUtilsTest.parseAllCertificatesOrKeysReturnsEveryBlockInMultiKeyArmor` — alice + bobby fixtures concatenated → 2 distinct IDs returned.
- `KeyUtilsTest.parseAllCertificatesOrKeysReturnsEmptyOnGarbage` — graceful failure.
- `PGPKeyManagerTest.importIteratesMultiKeyArmor` — end-to-end parse → iterate → `addKey` per cert → both `getKeyById` lookups succeed.

Manual (debug APK on device):
- `gpg --armor --export A B > both.asc` → PGP Key Manager → Import key. Summary dialog lists both IDs; both appear in the key list.
- Single-key import path unchanged.

## :pencil: Checklist
- [x] I formatted the code with `./gradlew spotlessApply`
- [x] I reviewed the submitted code
- [x] I added a [CHANGELOG](CHANGELOG.md) entry if applicable

## :crystal_ball: Next steps

The per-conflict "Replace?" prompt fires once per key. For users re-importing a large bundle that overlaps with existing keys this gets tappy — a "Replace all conflicts?" batched option would be nicer. Out of scope here.

## :camera_flash: Screenshots / GIFs

No UI restyling — just one summary dialog reusing the existing `MaterialAlertDialogBuilder` style. Happy to attach a recording if useful.
