### PR TITLE
import all keys from a multi-key backup file in PGP Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file
 ### Added
 
 - Search result filter options "exact match" and "fuzzy" in Settings --> General
+- PGP Manager now imports all keys from multi-key backups, such as those produced with OpenKeychain (previously, only the first key was imported)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,12 @@ The original documentation can be found [here](https://docs.passwordstore.app) a
 
 ## How-To: Transfer a PGP key to Password Store securely
 
-You can only import one PGP key at a time. If you need to transfer more than one key, repeat the steps for each key.
-
 ### From GPG keyring
 ````bash
 gpg --armor --gen-random 1 24 # generate a strong random password; use it in the next step
 gpg --armor --export-secret-keys <ID of key used for pass> | gpg --armor --symmetric --output myKeyForPass.sec.asc
 ````
-File `myKeyForPass.sec.asc` can be directly imported into Password Store; enter the password from the first step when asked for the backup code.
+File `myKeyForPass.sec.asc` can be directly imported into Password Store via Settings → PGP Settings → Key Manager → <kbd>+</kbd>; enter the password from the first step when asked for the backup code.
 
 ### From OpenKeychain
 1. In the main app window, select the key that you use for `pass`/Password Store from the "My Keys" list.

--- a/app/src/main/java/app/passwordstore/ui/pgp/PGPKeyImportActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/pgp/PGPKeyImportActivity.kt
@@ -14,7 +14,9 @@ import androidx.fragment.app.setFragmentResultListener
 import androidx.lifecycle.lifecycleScope
 import app.passwordstore.R
 import app.passwordstore.crypto.KeyUtils.isCertificateOrKey
+import app.passwordstore.crypto.KeyUtils.parseAllCertificatesOrKeys
 import app.passwordstore.crypto.KeyUtils.tryGetKeyId
+import app.passwordstore.crypto.PGPIdentifier
 import app.passwordstore.crypto.PGPKey
 import app.passwordstore.crypto.PGPKeyManager
 import app.passwordstore.crypto.errors.KeyAlreadyExistsException
@@ -42,17 +44,19 @@ import logcat.logcat
 @AndroidEntryPoint
 class PGPKeyImportActivity : AppCompatActivity() {
 
-  /**
-   * A [ByteArray] containing the contents of the previously selected file. This is necessary for
-   * the replacement case where we do not want users to have to pick the file again.
-   */
-  private var lastBytes: ByteArray? = null
   @Inject lateinit var pgpKeyManager: PGPKeyManager
   @Inject lateinit var repository: CryptoRepository
   @Inject lateinit var dispatcherProvider: DispatcherProvider
 
   private val MAX_RETRIES = 3
   private var retries = 0
+
+  /** Keys parsed from the picked file that are still waiting to be processed. */
+  private val pendingImports = mutableListOf<PGPKey>()
+  /** [PGPIdentifier.KeyId]s of keys that were successfully stored. */
+  private val importedKeyIds = mutableListOf<PGPIdentifier.KeyId>()
+  /** Keys that ultimately failed to import along with the reason. */
+  private val importFailures = mutableListOf<Pair<PGPKey, Throwable>>()
 
   private val pgpKeyImportAction =
     registerForActivityResult(GetContent()) { uri ->
@@ -66,7 +70,7 @@ class PGPKeyImportActivity : AppCompatActivity() {
             ?: throw IllegalStateException("Failed to open selected file")
         val bytes = keyInputStream.use { `is` -> `is`.readBytes() }
         if (isCertificateOrKey(PGPKey(bytes))) {
-          runCatching { importKey(bytes, false) }.run(::handleImportResult)
+          importAllKeys(bytes)
         } else {
           // incoming material may be a symmetrically encrypted key backup
           lifecycleScope.launch(dispatcherProvider.main()) { askBackupCode(bytes, isError = false) }
@@ -83,19 +87,69 @@ class PGPKeyImportActivity : AppCompatActivity() {
       }
   }
 
-  override fun onDestroy() {
-    lastBytes = null
-    super.onDestroy()
+  /**
+   * Splits [bytes] into one [PGPKey] per certificate/key block found and processes them
+   * sequentially. A multi-key armored file (e.g. produced by `gpg --export A B C`) yields several
+   * blocks; each is imported via [pgpKeyManager] independently, so partial failures
+   * (already-exists, unusable) are reported per key without aborting the rest.
+   */
+  private fun importAllKeys(bytes: ByteArray) {
+    pendingImports.clear()
+    importedKeyIds.clear()
+    importFailures.clear()
+    parseAllCertificatesOrKeys(PGPKey(bytes)).forEach {
+      pendingImports.add(PGPKey(it.getEncoded()))
+    }
+    processNextImport()
   }
 
-  private fun importKey(bytes: ByteArray, replace: Boolean): PGPKey? {
-    lastBytes = bytes
-    val (key, error) = pgpKeyManager.addKey(PGPKey(bytes), replace = replace)
-    if (replace) {
-      lastBytes = null
+  private fun processNextImport() {
+    if (pendingImports.isEmpty()) {
+      showImportSummary()
+      return
     }
+    val key = pendingImports.removeAt(0)
+    val result = runCatching { addKeyOrThrow(key, replace = false) }
+    handleSingleImportResult(result, key)
+  }
+
+  private fun handleSingleImportResult(result: Result<PGPKey?, Throwable>, sourceKey: PGPKey) {
+    if (result.isOk) {
+      result.get()?.let { tryGetKeyId(it)?.let(importedKeyIds::add) }
+      processNextImport()
+      return
+    }
+    val error = result.getError()
+    if (error is KeyAlreadyExistsException) {
+      val keyId = tryGetKeyId(sourceKey)
+      MaterialAlertDialogBuilder(this)
+        .setTitle(getString(R.string.pgp_key_import_failed))
+        .setMessage(getString(R.string.pgp_key_import_failed_replace_message, keyId))
+        .setPositiveButton(R.string.dialog_yes) { _, _ ->
+          val retry = runCatching { addKeyOrThrow(sourceKey, replace = true) }
+          if (retry.isOk) {
+            retry.get()?.let { tryGetKeyId(it)?.let(importedKeyIds::add) }
+          } else {
+            importFailures.add(sourceKey to (retry.getError() ?: error))
+          }
+          processNextImport()
+        }
+        .setNegativeButton(R.string.dialog_no) { _, _ ->
+          importFailures.add(sourceKey to error)
+          processNextImport()
+        }
+        .setCancelable(false)
+        .show()
+    } else {
+      importFailures.add(sourceKey to (error ?: NullPointerException()))
+      processNextImport()
+    }
+  }
+
+  private fun addKeyOrThrow(key: PGPKey, replace: Boolean): PGPKey? {
+    val (stored, error) = pgpKeyManager.addKey(key, replace = replace)
     if (error != null) throw error
-    return key
+    return stored
   }
 
   private suspend fun askBackupCode(bytes: ByteArray, isError: Boolean) {
@@ -122,58 +176,79 @@ class PGPKeyImportActivity : AppCompatActivity() {
     val result = repository.decryptSym(backupCode, message, outputStream)
     if (result.isOk) {
       val decryptedBytes = result.getOrThrow().toByteArray()
-      runCatching { importKey(decryptedBytes, false) }.run(::handleImportResult)
+      importAllKeys(decryptedBytes)
     } else {
       result.getError()?.let { logcat { it.asLog() } }
       askBackupCode(bytes, isError = true) // retry
     }
   }
 
-  private fun handleImportResult(result: Result<PGPKey?, Throwable>) {
-    if (result.isOk) {
-      val key = result.get()
-      if (key == null) {
-        setResult(RESULT_CANCELED)
-        finish()
-        /* This return convinces Kotlin that the control flow for `key == null` definitely
-        terminates here and allows for a smart cast below. */
-        return
+  private fun showImportSummary() {
+    if (importedKeyIds.isEmpty() && importFailures.isEmpty()) {
+      setResult(RESULT_CANCELED)
+      finish()
+      return
+    }
+
+    val successText =
+      resources.getQuantityString(
+        R.plurals.pgp_key_import_success_message,
+        importedKeyIds.size,
+        importedKeyIds.size,
+      ) + "\n\n" + importedKeyIds.joinToString(prefix = "\t", separator = "\n\t")
+
+    val failureText =
+      resources.getQuantityString(
+        R.plurals.pgp_key_import_failure_message,
+        importFailures.size,
+        importFailures.size,
+      ) +
+        "\n\n" +
+        importFailures.joinToString("\n") { (k, e) ->
+          val id = tryGetKeyId(k)?.toString() ?: "?"
+          val reason =
+            when (e) {
+              is KeyAlreadyExistsException -> getString(R.string.pgp_key_import_skipped_existing)
+              is UnusableKeyException -> getString(R.string.pgp_key_import_failed_unusable_message)
+              else -> e.message ?: e::class.simpleName ?: "error"
+            }
+          "$id: $reason"
+        }
+
+    val titleAndMessage =
+      if (importFailures.isEmpty()) { // all succeeded
+        resources.getQuantityString(
+          R.plurals.pgp_key_import_success_title,
+          importedKeyIds.size,
+          importedKeyIds.size,
+        ) to successText
+      } else if (importedKeyIds.isEmpty()) { // all failed
+        resources.getQuantityString(
+          R.plurals.pgp_key_import_failure_title,
+          importFailures.size,
+          importFailures.size,
+        ) to failureText
+      } else { // partial success
+        getString(R.string.pgp_key_import_partial_success_title) to
+          successText + "\n\n" + failureText
       }
-      val keyId = tryGetKeyId(key)
+
+    val builder =
       MaterialAlertDialogBuilder(this)
-        .setTitle(getString(R.string.pgp_key_import_succeeded))
-        .setMessage(getString(R.string.pgp_key_import_succeeded_message, keyId))
+        .setCancelable(false)
+        .setTitle(titleAndMessage.first)
+        .setMessage(titleAndMessage.second)
         .setPositiveButton(android.R.string.ok) { _, _ ->
-          setResult(RESULT_OK, Intent().putExtra("PGP_KEY_ID", keyId?.id ?: 0L))
+          if (importedKeyIds.isNotEmpty()) {
+            setResult(
+              RESULT_OK,
+              Intent().putExtra("PGP_KEY_IDS", importedKeyIds.map { it.id }.toLongArray()),
+            )
+          } else {
+            setResult(RESULT_CANCELED)
+          }
           finish()
         }
-        .setCancelable(false)
         .show()
-    } else {
-      val dialog =
-        MaterialAlertDialogBuilder(this)
-          .setTitle(getString(R.string.pgp_key_import_failed))
-          .setCancelable(false)
-
-      val error = result.getError()
-      if (error is KeyAlreadyExistsException && lastBytes != null) {
-        dialog
-          .setMessage(getString(R.string.pgp_key_import_failed_replace_message))
-          .setPositiveButton(R.string.dialog_yes) { _, _ ->
-            handleImportResult(
-              runCatching { importKey(lastBytes ?: throw NullPointerException(), replace = true) }
-            )
-          }
-          .setNegativeButton(R.string.dialog_no) { _, _ -> finish() }
-      } else {
-        val errMessage =
-          if (error is UnusableKeyException) {
-            getString(R.string.pgp_key_import_failed_unusable_message)
-          } else error?.message
-        dialog.setMessage(errMessage).setPositiveButton(android.R.string.ok) { _, _ -> finish() }
-      }
-
-      dialog.show()
-    }
   }
 }

--- a/app/src/main/java/app/passwordstore/ui/pgp/PGPKeyListActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/pgp/PGPKeyListActivity.kt
@@ -74,9 +74,12 @@ class PGPKeyListActivity : AppCompatActivity() {
       if (it.resultCode == RESULT_OK) {
         if (isAddingKeys) keysAdded = true
         it.data?.let { data ->
-          /* If we replace a key by itself, we unregister it as an authentication key,
-           * since the replacement may come without that capability */
-          if (data.getLongExtra("PGP_KEY_ID", 0L) == SshKey.pgpLongKeyId) SshKey.delete()
+          /* If we replace a key that is currently registered for SSH auth, drop the SSH
+           * registration; the cached key is a snapshot of the previous PGP auth subkey
+           * and may no longer match the replacement (different subkey, or no auth
+           * capability at all). Forcing a re-setup avoids silent SSH auth breakage. */
+          val importedIds = data.getLongArrayExtra("PGP_KEY_IDS") ?: longArrayOf()
+          if (SshKey.pgpLongKeyId in importedIds) SshKey.delete()
         }
         viewModel.updateKeySet()
       }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -309,9 +309,7 @@
     <string name="pgp_key_backupcode_title">Codi de còpia de seguretat</string>
     <string name="pgp_key_backupcode_confirmation">He anotat i guardat en un lloc segur el codi de còpia de seguretat.</string>
     <string name="pgp_key_import_failed">No s\'ha pogut importar la clau PGP</string>
-    <string name="pgp_key_import_failed_replace_message">S\'ha trobat un clau amb el mateix ID, voleu reemplaçar-la?</string>
-    <string name="pgp_key_import_succeeded">Clau PGP importada correctament</string>
-    <string name="pgp_key_import_succeeded_message">Comproveu la correcció del ID de la clau importada: %1$s</string>
+    <string name="pgp_key_import_failed_replace_message">S\'ha trobat un clau amb el mateix ID:\n\n\t%1$s\n\nVoleu reemplaçar-la?</string>
     <string name="pgp_key_export_failed">No s\'ha pogut exportar la clau PGP</string>
     <string name="pgp_key_export_succeeded">Clau PGP exportada correctament</string>
     <string name="pgp_full_name_hint">Nom complert</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: GPL-3.0-only
   -->
 
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
   <plurals name="delete_title">
     <item quantity="one">%d Element ausgewählt</item>
@@ -399,11 +399,27 @@
   <string name="pgp_new_pgp_key_title">PGP-Schlüssel erstellen</string>
   <string name="pgp_key_backupcode_title">Backup-Code</string>
   <string name="pgp_key_backupcode_confirmation">Ich habe den Backup-Code notiert und verwahre ihn an einem sicheren Ort.</string>
-  <string name="pgp_key_import_failed">Fehler beim Import des PGP-Schlüssels</string>
-  <string name="pgp_key_import_failed_replace_message">Ein bestehender Schlüssel mit dieser ID wurde gefunden. Möchten Sie ihn ersetzen?</string>
+  <string name="pgp_key_import_failed">Import des PGP-Schlüssels fehlgeschlagen</string>
+  <string name="pgp_key_import_failed_replace_message">Ein bestehender Schlüssel mit der folgenden ID wurde gefunden:\n\n\t%1$s\n\nMöchten Sie ihn ersetzen?</string>
   <string name="pgp_key_import_failed_unusable_message">Der angegebene Schlüssel ist nicht für die Verschlüsselung verwendbar. Stellen Sie sicher, dass ein Unterschlüssel für die Verschlüsselung existiert und dass dieser weder abgelaufen ist noch widerrufen wurde.</string>
-  <string name="pgp_key_import_succeeded">PGP-Schlüssel erfolgreich importiert</string>
-  <string name="pgp_key_import_succeeded_message">Die ID des importierten Schlüssels ist unten angegeben. Bitte überprüfen Sie deren Korrektheit:\n%1$s</string>
+  <string name="pgp_key_import_skipped_existing">Schlüssel existiert, Austausch übersprungen</string>
+  <plurals name="pgp_key_import_success_title">
+    <item quantity="one">PGP-Schlüssel erfolgreich importiert</item>
+    <item quantity="other">Alle PGP-Schlüssel erfolgreich importiert</item>
+  </plurals>
+  <plurals name="pgp_key_import_failure_title">
+    <item quantity="one">Kein PGP-Schlüssel importiert</item>
+    <item quantity="other">Keine PGP-Schlüssel importiert</item>
+  </plurals>
+  <string name="pgp_key_import_partial_success_title">Nicht alle PGP-Schlüssel wurden importiert</string>
+  <plurals name="pgp_key_import_success_message">
+    <item quantity="one">Die ID des importierten Schlüssels ist nachfolgend angegeben. Bitte überprüfen Sie deren Korrektheit:</item>
+    <item quantity="other">Die IDs der importierten Schlüssel sind nachfolgend angegeben. Bitte überprüfen Sie deren Korrektheit:</item>
+  </plurals>
+  <plurals name="pgp_key_import_failure_message">
+    <item quantity="one">Der Schlüssel mit der folgenden ID wurde nicht importiert:</item>
+    <item quantity="other">Schlüssel mit den folgenden IDs wurden nicht importiert:</item>
+  </plurals>
   <string name="pgp_key_export_failed">Fehler beim Export des PGP-Schlüssels</string>
   <string name="pgp_key_export_succeeded">PGP-Schlüssel erfolgreich exportiert</string>
   <string name="pgp_full_name_hint">Benutzername</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -365,9 +365,7 @@
   <string name="pgp_key_backupcode_title">Código de respaldo</string>
   <string name="pgp_key_backupcode_confirmation">He anotado el código de respaldo y lo he guardado en un lugar seguro.</string>
   <string name="pgp_key_import_failed">No se pudo importar la clave PGP</string>
-  <string name="pgp_key_import_failed_replace_message">Se encontró una clave existente con este ID, ¿desea reemplazarla?</string>
-  <string name="pgp_key_import_succeeded">Clave PGP importada correctamente</string>
-  <string name="pgp_key_import_succeeded_message">El ID de la clave importada se proporciona a continuación, revíselo para verificar que sea correcto:\n%1$s</string>
+  <string name="pgp_key_import_failed_replace_message">Se encontró una clave existente con este ID:\n\n\t%1$s\n\n¿Desea reemplazarla?</string>
   <string name="pgp_key_export_failed">No se pudo exportar la clave PGP</string>
   <string name="pgp_key_export_succeeded">Clave PGP exportada correctamente</string>
   <string name="pgp_full_name_hint">Nombre completo</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -293,7 +293,5 @@
   <string name="otp_import_manual_hint_account">Compte</string>
   <string name="password_list_fab_content_description">Créer un nouveau mot de passe ou dossier</string>
   <string name="pgp_key_import_failed">Impossible d\'importer la clé PGP</string>
-  <string name="pgp_key_import_succeeded">Clé PGP importée avec succès</string>
-  <string name="pgp_key_import_succeeded_message">La clé d\'identification de la clé importée est donné ci-dessous, veuillez la vérifier pour qu\'elle soit correcte :\n%1$s</string>
   <string name="pref_category_pgp_title">Paramètres PGP</string>
 </resources>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -309,9 +309,7 @@ a app desde unha fonte de confianza, como a Play Store, Amazon Appstore, F-Droid
   <string name="place_shortcut_on_home_screen">Crear atallo na pantalla de inicio</string>
   <string name="password_list_fab_content_description">Crear novo contrasinal ou cartafol</string>
   <string name="pgp_key_import_failed">Fallou a importación da chave PGP</string>
-  <string name="pgp_key_import_failed_replace_message">Atopouse unha chave existente con este ID, queres substituíla?</string>
-  <string name="pgp_key_import_succeeded">Chave PGP importada correctamente</string>
-  <string name="pgp_key_import_succeeded_message">Aquí abaixo está o ID da chave importada, comproba que é correcto:\n%1$s</string>
+  <string name="pgp_key_import_failed_replace_message">Atopouse unha chave existente con este ID:\n\n\t%1$s\n\nQueres substituíla?</string>
   <string name="pref_category_pgp_title">Axustes PGP</string>
   <string name="pwgen_some_error_occurred">Houbo un fallo</string>
   <string name="git_run_gc_job">Recolle o lixo</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -307,9 +307,7 @@ username@example.com:…</string>
   <string name="place_shortcut_on_home_screen">홈 화면에 추가</string>
   <string name="password_list_fab_content_description">새 비밀번호 또는 폴더 만들기</string>
   <string name="pgp_key_import_failed">PGP 키를 가져오지 못했습니다</string>
-  <string name="pgp_key_import_failed_replace_message">이 ID를 가진 기존 키가 발견되었습니다. 교체하시겠습니까?</string>
-  <string name="pgp_key_import_succeeded">PGP 키를 성공적으로 가져왔습니다</string>
-  <string name="pgp_key_import_succeeded_message">가져온 키의 키 ID는 다음과 같습니다. 정확한지 확인하시기 바랍니다:\n%1$s</string>
+  <string name="pgp_key_import_failed_replace_message">이 ID를 가진 기존 키가 발견되었습니다:\n\n\t%1$s\n\n교체하시겠습니까?</string>
   <string name="pref_category_pgp_title">PGP 설정</string>
   <string name="pwgen_some_error_occurred">오류가 발생했습니다</string>
   <string name="git_run_gc_job">메모리 정리 작업 수행</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -299,9 +299,7 @@
   <string name="place_shortcut_on_home_screen">Utwórz skrót na pulpicie</string>
   <string name="password_list_fab_content_description">Utwórz nowe hasło lub folder</string>
   <string name="pgp_key_import_failed">Nie udało się zaimportować klucza PGP</string>
-  <string name="pgp_key_import_failed_replace_message">Znaleziono istniejący klucz z tym identyfikatorem, czy chcesz go zastąpić?</string>
-  <string name="pgp_key_import_succeeded">Pomyślnie zaimportowano klucz PGP</string>
-  <string name="pgp_key_import_succeeded_message">ID zaimportowanego klucza jest podany poniżej, sprawdź go pod kątem poprawności:\n%1$s</string>
+  <string name="pgp_key_import_failed_replace_message">Znaleziono istniejący klucz z tym identyfikatorem:\n\n\t%1$s\n\nCzy chcesz go zastąpić?</string>
   <string name="pref_category_pgp_title">Ustawienia PGP</string>
   <string name="pwgen_some_error_occurred">Wystąpił błąd</string>
   <string name="git_run_gc_job">Uruchom operację sprzątania śmieci</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -307,9 +307,7 @@
   <string name="place_shortcut_on_home_screen">Criar atalho na tela inicial</string>
   <string name="password_list_fab_content_description">Criar nova senha ou pasta</string>
   <string name="pgp_key_import_failed">Falha ao importar a chave PGP</string>
-  <string name="pgp_key_import_failed_replace_message">Uma chave existente com esse ID foi encontrada, você deseja substituí-lo?</string>
-  <string name="pgp_key_import_succeeded">Chave PGP importada com sucesso</string>
-  <string name="pgp_key_import_succeeded_message">A ID da chave importada foi fornecida abaixo, por favor, faça uma revisão para correção:\n%1$s</string>
+  <string name="pgp_key_import_failed_replace_message">Uma chave existente com esse ID foi encontrada:\n\n\t%1$s\n\nVocê deseja substituí-lo?</string>
   <string name="pref_category_pgp_title">Configurações PGP</string>
   <string name="pwgen_some_error_occurred">Ocorreu um erro</string>
   <string name="git_run_gc_job">Executar o serviço de limpeza</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -303,5 +303,4 @@
   <string name="place_shortcut_on_home_screen">Разместить ярлык на рабочем столе</string>
   <string name="password_list_fab_content_description">Создать новый пароль или папку</string>
   <string name="pgp_key_import_failed">Не удалось импортировать PGP-ключ</string>
-  <string name="pgp_key_import_succeeded">PGP ключ успешно импортирован</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -359,9 +359,7 @@
   <string name="pgp_key_backupcode_title">Yedekleme kodu</string>
   <string name="pgp_key_backupcode_confirmation">Yedekleme kodunu not aldım ve güvenli bir yerde sakladım.</string>
   <string name="pgp_key_import_failed">PGP anahtarı içe aktarılamadı</string>
-  <string name="pgp_key_import_failed_replace_message">Bu kimliğe sahip mevcut bir anahtar bulundu, değiştirmek istiyor musunuz?</string>
-  <string name="pgp_key_import_succeeded">PGP anahtarı başarıyla içe aktarıldı</string>
-  <string name="pgp_key_import_succeeded_message">İçe aktarılan anahtarın kimliği aşağıda verilmiştir, lütfen doğruluğunu kontrol edin:\n%1$s</string>
+  <string name="pgp_key_import_failed_replace_message">Bu kimliğe sahip mevcut bir anahtar bulundu:\n\n\t%1$s\n\nDeğiştirmek istiyor musunuz?</string>
   <string name="pgp_key_export_failed">PGP anahtarı dışa aktarılamadı</string>
   <string name="pgp_key_export_succeeded">PGP anahtarı başarıyla dışa aktarıldı</string>
   <string name="pref_category_pgp_title">PGP ayarları</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -310,9 +310,7 @@ personal.com</string>
   <string name="place_shortcut_on_home_screen">在主屏幕上放置快捷方式</string>
   <string name="password_list_fab_content_description">创建新密码或文件夹</string>
   <string name="pgp_key_import_failed">导入 PGP 密钥失败</string>
-  <string name="pgp_key_import_failed_replace_message">发现了 ID 相同的现有密钥，您要替换它吗？</string>
-  <string name="pgp_key_import_succeeded">成功导入 PGP 密钥</string>
-  <string name="pgp_key_import_succeeded_message">下面给出了导入密钥的 key ID，请检查它是否正确：\n%1$s</string>
+  <string name="pgp_key_import_failed_replace_message">发现了 ID 相同的现有密钥，:\n\n\t%1$s\n\n您要替换它吗？</string>
   <string name="pref_category_pgp_title">PGP 设置</string>
   <string name="pwgen_some_error_occurred">发生某些错误</string>
   <string name="git_run_gc_job">运行垃圾收集作业</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -401,10 +401,26 @@
   <string name="pgp_key_backupcode_title">Backup code</string>
   <string name="pgp_key_backupcode_confirmation">I have noted down the backup code and stored it in a safe place.</string>
   <string name="pgp_key_import_failed">Failed to import PGP key</string>
-  <string name="pgp_key_import_failed_replace_message">An existing key with this ID was found, do you want to replace it?</string>
+  <string name="pgp_key_import_failed_replace_message">An existing key with the following ID was found:\n\n\t%1$s\n\nDo you want to replace it?</string>
   <string name="pgp_key_import_failed_unusable_message">The given key is not usable for encryption. Please ensure that a subkey for encryption exists and that it has not expired or been revoked.</string>
-  <string name="pgp_key_import_succeeded">Successfully imported PGP key</string>
-  <string name="pgp_key_import_succeeded_message">The key ID of the imported key is given below, please review it for correctness:\n%1$s</string>
+  <string name="pgp_key_import_skipped_existing">Key already exists (replacement skipped)</string>
+  <plurals name="pgp_key_import_success_title">
+    <item quantity="one">PGP key successfully imported</item>
+    <item quantity="other">All PGP keys successfully imported</item>
+  </plurals>
+  <plurals name="pgp_key_import_failure_title">
+    <item quantity="one">No PGP key imported</item>
+    <item quantity="other">No PGP keys imported</item>
+  </plurals>
+  <string name="pgp_key_import_partial_success_title">Not all PGP keys imported</string>
+  <plurals name="pgp_key_import_success_message">
+    <item quantity="one">The imported key has the following ID; please verify its correctness:</item>
+    <item quantity="other">The imported keys have the following IDs; please verify their correctness:</item>
+  </plurals>
+  <plurals name="pgp_key_import_failure_message">
+    <item quantity="one">The key with the following ID was not imported:</item>
+    <item quantity="other">Keys with the following IDs were not imported:</item>
+  </plurals>
   <string name="pgp_key_export_failed">Failed to export PGP key</string>
   <string name="pgp_key_export_succeeded">Successfully exported PGP key</string>
   <string name="pgp_full_name_hint">Full name</string>

--- a/crypto/pgpainless/src/main/kotlin/app/passwordstore/crypto/KeyUtils.kt
+++ b/crypto/pgpainless/src/main/kotlin/app/passwordstore/crypto/KeyUtils.kt
@@ -8,6 +8,7 @@ package app.passwordstore.crypto
 import app.passwordstore.crypto.PGPIdentifier.KeyId
 import app.passwordstore.crypto.PGPIdentifier.UserId
 import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getOr
 import com.github.michaelbull.result.runCatching
 import java.security.PublicKey
 import java.util.Date
@@ -34,6 +35,31 @@ public object KeyUtils {
         incoming.filter { it.isSecretKey() }?.firstOrNull() ?: incoming.firstOrNull()
       }
       .get()
+
+  /**
+   * Parses every PGP certificate or key block contained in [key]'s payload. A typical multi-key
+   * file (e.g. produced by `gpg --export A B C`) holds several concatenated blocks; this helper
+   * yields one [OpenPGPCertificate] per block, with any secret keys ordered before public
+   * certificates to match the preference used by [tryParseCertificateOrKey]. The elements in the
+   * sorted list need to be visited once more to strip those public certificates whose secret
+   * counterpart with the same key ID has already been included.
+   *
+   * Returns an empty list if parsing fails or no key is found.
+   */
+  public fun parseAllCertificatesOrKeys(key: PGPKey): List<OpenPGPCertificate> =
+    runCatching {
+        var primaryKeyIds = mutableListOf<Long>()
+        OpenPGPKeyReader()
+          .parseKeysOrCertificates(key.contents.inputStream())
+          .sortedByDescending { cert ->
+            cert.isSecretKey()
+          }
+          .filterNot { cert ->
+            val primaryKeyId = cert.getKeyIdentifier().getKeyId()
+            primaryKeyIds.contains(primaryKeyId).also { primaryKeyIds.add(primaryKeyId) }
+          }
+      }
+      .getOr(emptyList())
 
   /**
    * Parses an [OpenPGPPrimaryKey] from the given [PGPKey] and calculates its long primary key ID
@@ -161,8 +187,8 @@ public object KeyUtils {
     /* A and S subkeys as well as the primary C key are equally suitable for authentication;
      * we pick the first subkey matching one of the capabilities in the given ranking order: */
     val authFlags = listOf(KeyFlags.AUTHENTICATION, KeyFlags.SIGN_DATA, KeyFlags.CERTIFY_OTHER)
-    val subkeys = cert.getSecretKeys().values.toMutableList()
-    subkeys.sortByDescending { it.getCreationTime() } // newest first
+    val subkeys =
+      cert.getSecretKeys().values.sortedByDescending { it.getCreationTime() } // newest first
     val authKeys =
       authFlags
         .map { flag ->

--- a/crypto/pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPainlessCryptoHandler.kt
+++ b/crypto/pgpainless/src/main/kotlin/app/passwordstore/crypto/PGPainlessCryptoHandler.kt
@@ -226,8 +226,10 @@ public class PGPainlessCryptoHandler @Inject constructor() :
         /* A and S subkeys as well as the primary C key are equally suitable for authentication;
          * we pick the first one matching one of the capabilities in the given ranking order */
         val authFlags = listOf(KeyFlags.AUTHENTICATION, KeyFlags.SIGN_DATA, KeyFlags.CERTIFY_OTHER)
-        val subkeys = openPgpKey.getSecretKeys().values.toMutableList()
-        subkeys.sortByDescending { it.getCreationTime() } // newest first
+        val subkeys =
+          openPgpKey.getSecretKeys().values.sortedByDescending {
+            it.getCreationTime()
+          } // newest first
         val authKeys =
           authFlags
             .map { flag ->

--- a/crypto/pgpainless/src/test/kotlin/app/passwordstore/crypto/KeyUtilsTest.kt
+++ b/crypto/pgpainless/src/test/kotlin/app/passwordstore/crypto/KeyUtilsTest.kt
@@ -7,6 +7,7 @@ package app.passwordstore.crypto
 
 import app.passwordstore.crypto.KeyUtils.isKeyUsable
 import app.passwordstore.crypto.KeyUtils.isSecretKey
+import app.passwordstore.crypto.KeyUtils.parseAllCertificatesOrKeys
 import app.passwordstore.crypto.KeyUtils.tryGetKeyId
 import app.passwordstore.crypto.KeyUtils.tryParseCertificateOrKey
 import app.passwordstore.crypto.TestUtils.AllKeys
@@ -32,6 +33,26 @@ class KeyUtilsTest {
     assertNotNull(keyId)
     assertIs<PGPIdentifier.KeyId>(keyId)
     assertEquals("b950ae2813841585", keyId.toString())
+  }
+
+  @Test
+  fun parseAllCertificatesOrKeysReturnsEveryBlockInMultiKeyArmor() {
+    val aliceBytes =
+      this::class.java.classLoader.getResource("alice_owner@example_com")!!.readBytes()
+    val bobbyBytes =
+      this::class.java.classLoader.getResource("bobby_owner@example_com")!!.readBytes()
+    val combined = aliceBytes + "\n".toByteArray() + bobbyBytes
+
+    val parsed = parseAllCertificatesOrKeys(PGPKey(combined))
+    assertEquals(2, parsed.size)
+    val ids = parsed.map { tryGetKeyId(it).toString() }.toSet()
+    assertEquals(2, ids.size, "expected two distinct key IDs but got $ids")
+  }
+
+  @Test
+  fun parseAllCertificatesOrKeysReturnsEmptyOnGarbage() {
+    val garbage = PGPKey("not a pgp key".toByteArray())
+    assertEquals(emptyList(), parseAllCertificatesOrKeys(garbage))
   }
 
   @Test

--- a/crypto/pgpainless/src/test/kotlin/app/passwordstore/crypto/PGPKeyManagerTest.kt
+++ b/crypto/pgpainless/src/test/kotlin/app/passwordstore/crypto/PGPKeyManagerTest.kt
@@ -8,6 +8,7 @@ package app.passwordstore.crypto
 // import app.passwordstore.crypto.errors.UnusableKeyException
 import app.passwordstore.crypto.CryptoConstants.KEY_PASSPHRASE
 import app.passwordstore.crypto.CryptoConstants.PLAIN_TEXT
+import app.passwordstore.crypto.KeyUtils.parseAllCertificatesOrKeys
 import app.passwordstore.crypto.KeyUtils.tryGetKeyId
 import app.passwordstore.crypto.PGPIdentifier.KeyId
 import app.passwordstore.crypto.PGPIdentifier.UserId
@@ -223,6 +224,30 @@ class PGPKeyManagerTest {
   fun replaceSecretKeyWithSecretKey() {
     assertTrue(keyManager.addKey(secretKey).isOk)
     assertTrue(keyManager.addKey(secretKey).isErr)
+  }
+
+  @Test
+  fun importIteratesMultiKeyArmor() {
+    val aliceBytes =
+      this::class.java.classLoader.getResource("alice_owner@example_com")!!.readBytes()
+    val bobbyBytes =
+      this::class.java.classLoader.getResource("bobby_owner@example_com")!!.readBytes()
+    val combined = aliceBytes + "\n".toByteArray() + bobbyBytes
+
+    val parsedCerts = parseAllCertificatesOrKeys(PGPKey(combined))
+    assertEquals(2, parsedCerts.size)
+
+    parsedCerts.forEach { cert ->
+      val perKey = PGPKey(cert.toAsciiArmoredString().toByteArray())
+      assertTrue(keyManager.addKey(perKey).isOk)
+    }
+
+    keyManager.getAllKeys().apply {
+      assertTrue(this.isOk)
+      assertEquals(2, this.unwrap().size)
+    }
+    assertTrue(keyManager.getKeyById(KeyId(-7087927403306410599)).isOk) // Alice
+    assertTrue(keyManager.getKeyById(KeyId(-961222705095032109)).isOk) // Bobby
   }
 
   @Test


### PR DESCRIPTION
* Previously, only the first secret key found in a key backup was picked and imported. Multi-key backups are usually exported from OpenKeychain or from GnuPG running `gpg --export-secret-keys A B C`

  Assisted-By: claude-opus-4-7 via Claude Code

* fixes and refactorings of multi-key import

  - public certs need to be stripped from the import list if their secret counterpart has already been included
  - improving consistency of results report
  - related translations added/fixed