### PR TITLE
fix: prevent crash on empty timeout preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file
 ### Fixed
 
 - Accidental overwriting of existing password items of same file name after editing
+- Empty preference value after fresh install for PIN/biometrics expiration timeout may cause the app to crash
 
 ## [1.16.3] - 2026-04-15
 

--- a/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
@@ -624,7 +624,8 @@ open class BasePGPActivity : AppCompatActivity() {
     val biometrics_and_pin_last_use =
       persistentPassphrases.getLong(PreferenceKeys.BIOMETRICS_AND_PIN_LAST_USE, 0L)
     val biometrics_and_pin_timeout =
-      settings.getString(PreferenceKeys.BIOMETRICS_AND_PIN_TIMEOUT)?.toLong() ?: 3L
+      settings.getString(PreferenceKeys.BIOMETRICS_AND_PIN_TIMEOUT)?.toLongOrNull()
+        ?: Constants.DEFAULT_BIOMETRICS_AND_PIN_TIMEOUT.toLong()
     if (
       biometrics_and_pin_timeout > 0L &&
         now - biometrics_and_pin_last_use >= TimeUnit.DAYS.toMillis(biometrics_and_pin_timeout)

--- a/app/src/main/java/app/passwordstore/util/settings/Constants.kt
+++ b/app/src/main/java/app/passwordstore/util/settings/Constants.kt
@@ -7,4 +7,5 @@ package app.passwordstore.util.settings
 
 object Constants {
   const val DEFAULT_DECRYPTION_TIMEOUT = 60
+  const val DEFAULT_BIOMETRICS_AND_PIN_TIMEOUT = 3
 }


### PR DESCRIPTION
The unset timeout value for biometrics/PIN after a fresh install may cause the app to crash when `String.toLong()` is applied on an empty string. Could fix #810.