### PR TITLE
stop infinite self-update loop

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,6 +50,7 @@
       description: 'Packages to be excluded from updates',
       matchPackageNames: [
         'org.eclipse.jgit', // Android 13+ required for JGit v6.3+
+		'agrahn/Android-Password-Store', // prevent infinte self-update loop
       ],
     },
   ],


### PR DESCRIPTION
... triggered by renovate
Fix suggested by @msfjarvis (https://github.com/agrahn/Android-Password-Store/pull/916#issuecomment-4737951107). Closes #916.