### PR TITLE
Allow reusing imeSpecs

### DIFF
--- a/app/src/main/java/app/passwordstore/util/autofill/Api30AutofillResponseBuilder.kt
+++ b/app/src/main/java/app/passwordstore/util/autofill/Api30AutofillResponseBuilder.kt
@@ -184,14 +184,13 @@ class Api30AutofillResponseBuilder private constructor(form: FillableForm) :
     matchedFiles: List<File>,
   ): FillResponse? {
     var datasetCount = 0
-    val maxSuggestions = inlineSuggestionsRequest?.maxSuggestionCount
-      ?: InlineSuggestionsRequest.SUGGESTION_COUNT_UNLIMITED
+    val maxSuggestions =
+      inlineSuggestionsRequest?.maxSuggestionCount
+        ?: InlineSuggestionsRequest.SUGGESTION_COUNT_UNLIMITED
     val imeSpecs = inlineSuggestionsRequest?.inlinePresentationSpecs ?: emptyList()
     fun nextImeSpec(): InlinePresentationSpec? =
       when {
-        datasetCount < maxSuggestions ->
-          imeSpecs.getOrNull(datasetCount) ?: imeSpecs.lastOrNull()
-
+        datasetCount < maxSuggestions -> imeSpecs.getOrNull(datasetCount) ?: imeSpecs.lastOrNull()
         else -> null
       }
     return FillResponse.Builder().run {

--- a/app/src/main/java/app/passwordstore/util/autofill/Api30AutofillResponseBuilder.kt
+++ b/app/src/main/java/app/passwordstore/util/autofill/Api30AutofillResponseBuilder.kt
@@ -184,19 +184,28 @@ class Api30AutofillResponseBuilder private constructor(form: FillableForm) :
     matchedFiles: List<File>,
   ): FillResponse? {
     var datasetCount = 0
+    val maxSuggestions = inlineSuggestionsRequest?.maxSuggestionCount
+      ?: InlineSuggestionsRequest.SUGGESTION_COUNT_UNLIMITED
     val imeSpecs = inlineSuggestionsRequest?.inlinePresentationSpecs ?: emptyList()
+    fun nextImeSpec(): InlinePresentationSpec? =
+      when {
+        datasetCount < maxSuggestions ->
+          imeSpecs.getOrNull(datasetCount) ?: imeSpecs.lastOrNull()
+
+        else -> null
+      }
     return FillResponse.Builder().run {
       for (file in matchedFiles) {
-        makeMatchDataset(context, file, imeSpecs.getOrNull(datasetCount))?.let {
+        makeMatchDataset(context, file, nextImeSpec())?.let {
           datasetCount++
           addDataset(it)
         }
       }
-      makeGenerateDataset(context, imeSpecs.getOrNull(datasetCount))?.let {
+      makeGenerateDataset(context, nextImeSpec())?.let {
         datasetCount++
         addDataset(it)
       }
-      makeSearchDataset(context, imeSpecs.getOrNull(datasetCount))?.let {
+      makeSearchDataset(context, nextImeSpec())?.let {
         datasetCount++
         addDataset(it)
       }


### PR DESCRIPTION
Fixes #1015

This is documented as Android's intended API contract in https://developer.android.com/reference/kotlin/android/view/inputmethod/InlineSuggestionsRequest?hl=en#getinlinepresentationspecs:

> If the max suggestion count is larger than the number of specs in the list, then the last spec is used for the remainder of the suggestions.

Before:

<img width="1080" height="408" alt="image" src="https://github.com/user-attachments/assets/5df514bb-1b83-440e-8738-134634054b6a" />

After:

<img width="1080" height="238" alt="image" src="https://github.com/user-attachments/assets/393aefa7-3737-4beb-80d5-d0269678eccc" />
