### PR TITLE
Add configurable save directory for Autofill-saved entries

### DIFF
--- a/app/src/main/java/app/passwordstore/ui/autofill/AutofillSaveActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/autofill/AutofillSaveActivity.kt
@@ -128,6 +128,7 @@ class AutofillSaveActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     val repo = PasswordRepository.getRepositoryDirectory()
+    val saveRoot = AutofillPreferences.saveDirectory(this)
     val saveIntent =
       Intent(this, PasswordCreationActivity::class.java).apply {
         putExtras(
@@ -136,7 +137,7 @@ class AutofillSaveActivity : AppCompatActivity() {
               putString(BasePGPActivity.EXTRA_REPO_PATH, repo.absolutePath)
               putString(
                 BasePGPActivity.EXTRA_FILE_PATH,
-                repo
+                saveRoot
                   .resolve(intent.getStringExtra(EXTRA_FOLDER_NAME) ?: throw NullPointerException())
                   .absolutePath,
               )

--- a/app/src/main/java/app/passwordstore/ui/settings/AutofillSettings.kt
+++ b/app/src/main/java/app/passwordstore/ui/settings/AutofillSettings.kt
@@ -109,6 +109,18 @@ class AutofillSettings(private val activity: FragmentActivity) : SettingsProvide
         summaryProvider = { activity.getString(R.string.preference_custom_public_suffixes_summary) }
         textInputHintRes = R.string.preference_custom_public_suffixes_hint
       }
+      editText(PreferenceKeys.AUTOFILL_SAVE_DIRECTORY) {
+        dependency = PreferenceKeys.AUTOFILL_ENABLE
+        titleRes = R.string.preference_autofill_save_directory_title
+        summaryProvider = { value ->
+          activity.getString(
+            R.string.preference_autofill_save_directory_summary,
+            value?.takeUnless { it.isBlank() }
+              ?: activity.getString(R.string.preference_autofill_save_directory_root_placeholder),
+          )
+        }
+        textInputHintRes = R.string.preference_autofill_save_directory_hint
+      }
     }
   }
 }

--- a/app/src/main/java/app/passwordstore/util/autofill/AutofillPreferences.kt
+++ b/app/src/main/java/app/passwordstore/util/autofill/AutofillPreferences.kt
@@ -7,6 +7,7 @@ package app.passwordstore.util.autofill
 import android.content.Context
 import androidx.core.content.edit
 import app.passwordstore.data.passfile.PasswordEntry
+import app.passwordstore.data.repo.PasswordRepository
 import app.passwordstore.util.extensions.getString
 import app.passwordstore.util.extensions.sharedPrefs
 import app.passwordstore.util.services.getDefaultUsername
@@ -20,6 +21,25 @@ object AutofillPreferences {
   fun directoryStructure(context: Context): DirectoryStructure {
     val value = context.sharedPrefs.getString(PreferenceKeys.DIRECTORY_STRUCTURE)
     return DirectoryStructure.fromValue(value)
+  }
+
+  /**
+   * The directory Autofill-saved credentials should be placed under, relative to the repository
+   * root. Backed by [PreferenceKeys.AUTOFILL_SAVE_DIRECTORY]; falls back to the repository root
+   * itself when unset. This only affects saves made through the Autofill framework (the system
+   * "Save to Password Store?" prompt) — it has no effect on entries created from within the app.
+   */
+  fun saveDirectory(context: Context): File {
+    val root = PasswordRepository.getRepositoryDirectory()
+    // Drop empty and ".." segments to prevent escaping the repository root.
+    val configured =
+      context.sharedPrefs
+        .getString(PreferenceKeys.AUTOFILL_SAVE_DIRECTORY)
+        ?.split('/')
+        ?.filter { it.isNotBlank() && it != ".." }
+        ?.joinToString("/")
+        ?.takeUnless { it.isBlank() }
+    return if (configured == null) root else root.resolve(configured)
   }
 
   fun strictDomainSearch(context: Context): Boolean {

--- a/app/src/main/java/app/passwordstore/util/settings/PreferenceKeys.kt
+++ b/app/src/main/java/app/passwordstore/util/settings/PreferenceKeys.kt
@@ -58,6 +58,7 @@ object PreferenceKeys {
   const val OREO_AUTOFILL_CUSTOM_PUBLIC_SUFFIXES = "oreo_autofill_custom_public_suffixes"
   const val OREO_AUTOFILL_DEFAULT_USERNAME = "oreo_autofill_default_username"
   const val DIRECTORY_STRUCTURE = "oreo_autofill_directory_structure"
+  const val AUTOFILL_SAVE_DIRECTORY = "oreo_autofill_save_directory"
   const val STRICT_DOMAIN_SEARCH = "oreo_autofill_strict_domain_search"
   const val PREF_KEY_PWGEN_TYPE = "pref_key_pwgen_type"
   const val REPOSITORY_INITIALIZED = "repository_initialized"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -330,6 +330,10 @@
   <string name="preference_custom_public_suffixes_title">Custom domains</string>
   <string name="preference_custom_public_suffixes_summary">Autofill will distinguish subdomains of these domains.</string>
   <string name="preference_custom_public_suffixes_hint">company.com\npersonal.com</string>
+  <string name="preference_autofill_save_directory_title">Save directory</string>
+  <string name="preference_autofill_save_directory_summary">Credentials saved via Autofill are placed under this folder instead of the store root. Currently: %1$s</string>
+  <string name="preference_autofill_save_directory_hint">e.g. www</string>
+  <string name="preference_autofill_save_directory_root_placeholder">store root</string>
 
   <!-- Password creation/edit -->
   <string name="password_creation_edit_file_encryption_success_title">Entry edited</string>


### PR DESCRIPTION
## Summary
- Credentials saved via the Autofill framework (the system "Save to Password Store?" prompt, shown while the app is closed) are always written directly to the repository root, with no way to route them into a category subfolder.
- Adds a **"Save directory"** setting under Settings > Autofill (`AutofillPreferences.saveDirectory()`) that lets users specify a root subfolder (e.g. `www`); Autofill-originated saves are then resolved under that folder instead of the store root.
- Scoped entirely to the Autofill save path (`AutofillSaveActivity`) — leaving it unset preserves existing behavior exactly, and the in-app "+" entry creation flow is unaffected in every case.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` — builds clean against `develop`
- [ ] Manual: set "Save directory" to `www`, trigger an Autofill save prompt on a new site, confirm the entry lands at `www/<site>/<file>` instead of the store root
- [ ] Manual: leave "Save directory" empty, confirm Autofill saves still land at the store root as before