### PR TITLE
fix alert dialogs clipped by IME on short screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file
 
 ### Fixed
 
+- Alert dialogs no longer get clipped by the keyboard on short screens
 - During PGP key selection, pressing the system navigation bar's back-button instead of the action bar's back arrow did not select the checkmarked key(s)
 - The selected password file organisation (in General settings) is now honoured when new entries are manually created
 - During autofill, login form fields are now pre-filled with the newly created credentials

--- a/app/src/main/res/values/themes_material3.xml
+++ b/app/src/main/res/values/themes_material3.xml
@@ -12,6 +12,7 @@
     <item name="android:navigationBarColor">?android:colorBackground</item>
     <item name="toolbarStyle">@style/APSThemeM3.Toolbar</item>
     <item name="bottomSheetDialogTheme">@style/APSThemeM3.BottomSheetDialog</item>
+    <item name="materialAlertDialogTheme">@style/APSThemeM3.AlertDialog</item>
   </style>
 
   <style name="NoBackgroundThemeM3" parent="@style/AppThemeM3">
@@ -42,6 +43,15 @@
     <item name="android:windowIsFloating">false</item>
     <item name="android:statusBarColor">@android:color/transparent</item>
     <item name="android:navigationBarColor">@android:color/transparent</item>
+  </style>
+
+  <style name="APSThemeM3.AlertDialog" parent="ThemeOverlay.Material3.MaterialAlertDialog">
+    <item name="alertDialogStyle">@style/APSThemeM3.AlertDialog.Style</item>
+  </style>
+
+  <style name="APSThemeM3.AlertDialog.Style" parent="MaterialAlertDialog.Material3">
+    <item name="backgroundInsetTop">0dp</item>
+    <item name="backgroundInsetBottom">0dp</item>
   </style>
 
   <style name="APSThemeM3" parent="Theme.Material3.DayNight">


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] Bugfix

## :scroll: Description

Override Material AlertDialog's vertical background insets globally while retaining the standard horizontal margins.

## :bulb: Motivation and Context

Fixes #1064.

This prevents input dialogs from being clipped when the IME reduces available height on short screens, including the Galaxy Z Fold8 cover display.

## :green_heart: How did you test it?

- Tested the PGP passphrase prompt with the IME visible on a Galaxy Z Fold8 cover display.
- Tested an ordinary confirmation dialog.
- Ran `./gradlew test -PslimTests`.

## :pencil: Checklist

- [x] I formatted the code with `./gradlew spotlessApply`
- [x] I reviewed the submitted code
- [x] I added a CHANGELOG entry if applicable

## :camera_flash: Screenshots / GIFs

Before:

![Passphrase prompt clipped above the keyboard](https://github.com/user-attachments/assets/f99703fc-f301-45c1-9938-cb91344b9d3a)

After:

![Passphrase prompt usable above the keyboard](https://github.com/user-attachments/assets/cdb0018f-d426-4592-89e7-b99fcd1e4e72)
